### PR TITLE
Enhance single-object efficiency corrections and RecoKaonTrack support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,6 @@ The main TTree (`X_One_Tree`) stores:
 ### Naming Conventions
 - Resonance candidates: `Jpsi_1_*`, `Jpsi_2_*`, `Ups_*`, `Phi_*` (suffixes: mass, ctau, px/py/pz, pt/eta/phi)
 - Muon indices: `Jpsi_1_mu_1_Idx`, `Jpsi_1_mu_2_Idx` (links muons to resonances)
-- Kaon indices: `Phi_K_1_Idx`, `Phi_K_2_Idx` (links kaons to φ, raw nonMuonTrack_ index)
 - Kaon RecoKaonTrack indices: `Phi_K_1_RecoKaonTrackIdx`, `SinglePhi_K1_RecoKaonTrackIdx` (links into `RecoKaonTrack_*` block)
 - Single-object candidates: `SingleJpsi_*`, `SingleUps_*`, `SinglePhi_*` (all-store MC efficiency branches)
 - Uncertainties: `*_pxErr`, `*_pyErr`, `*_pzErr`, `*_ptErr`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,25 @@ cmsRun HeavyFlavorAnalysis/TPS-Onia2MuMu/test/ConfFile_cfg.py \
     outputFile=output.root \
     era=Run2023C
 
-# MC
-cmsRun HeavyFlavorAnalysis/TPS-Onia2MuMu/test/runMultiLepPAT_MCRun3_miniAOD_Run2022.py \
+# MC (via ConfFile_cfg.py VarParsing)
+cmsRun HeavyFlavorAnalysis/TPS-Onia2MuMu/test/ConfFile_cfg.py \
     inputFiles=file:myMC.root \
-    outputFile=mc_output.root
+    outputFile=mc_output.root \
+    runOnMC=True \
+    era=Run2022
+
+# MC single-object efficiency ntuple (skip composite building)
+cmsRun HeavyFlavorAnalysis/TPS-Onia2MuMu/test/ConfFile_cfg.py \
+    inputFiles=file:myMC.root \
+    outputFile=mc_singles.root \
+    runOnMC=True \
+    era=Run2022 \
+    keepAllSingleObjectCandsInMC=True \
+    skipCompositeCandBuildingWhenKeepingSingles=True
 
 # Switch analysis mode
-cmsRun ConfFile_cfg.py AnalysisMode=JpsiUpsPhi
+cmsRun HeavyFlavorAnalysis/TPS-Onia2MuMu/test/ConfFile_cfg.py \
+    analysisMode=JpsiUpsPhi
 ```
 
 ### CRAB Submission
@@ -58,9 +70,11 @@ The core analysis is in `MultiLepPAT` (`interface/MultiLepPAT.h`, `src/MultiLepP
 4. **fillMuonBlock()** - Store muon kinematics and ID variables
 5. **pairMuons()** - Build dimuon candidates (J/ψ or Υ) via kinematic vertex fit
 6. **pairTracks()** - Build track-pair candidates (φ or other mesons)
-7. **combineCandidates()** - Combine resonances into 3-body candidates
-8. **doMCGenMatching()** - RECO-to-GEN matching for efficiency studies
+7. **storeAllSingleObjectCandidatesForMC()** - Store single-object J/ψ, Υ, φ candidates and the RecoKaonTrack block (MC efficiency studies)
+8. **combineCandidates()** - Combine resonances into 3-body candidates
 9. **clearEventData()** - Clear event-level storage
+
+Pairs are built at most once per event. Capability flags (`canTrySingleJpsi`, `canTryFullMuonSide`, etc.) and `hasFullCandidateInputs()` gate whether each step runs. `shouldFillCurrentEvent()` controls TTree fill based on candidate presence, MC mode, and `RequireAcceptedCandidatesForMonteCarloTree`.
 
 ### Configuration Architecture
 
@@ -69,8 +83,21 @@ All selection cuts are externalized via `StringCutObjectSelector` syntax, enabli
 - `MuonSelection` - String cut on `pat::Muon` members (e.g., `"pt > 2.5 && abs(eta) < 2.4"`)
 - `TrackSelection` - String cut on `pat::PackedCandidate` for kaons/pions
 - Mass windows (`JpsiMassMin/Max`, `UpsMassMin/Max`, `PhiMassMin/Max`)
+- Candidate pT/eta pre-cuts (`JpsiCandPtMin`, `JpsiCandEtaMax`, `UpsCandPtMin`, `UpsCandEtaMax`, `PhiCandPtMin`, `PhiCandEtaMax`)
 - Vertex probability cuts (`OniaDecayVtxProbCut`, `PriVtxProbCut`)
 - Primary vertex quality (`PVNdofMin`, `PVMaxAbsZ`, `PVMaxRho`)
+- Vertex fit toggles (`DoJpsiDecayVtxFit`, `DoUpsDecayVtxFit`, `DoPhiDecayVtxFit`, `DoDiOniaVtxFit`, `DoPriVtxFit`) — enable/disable individual kinematic fits
+
+### MC Control (VarParsing CLI only, not in canned configs)
+
+- `runOnMC` — enables `DoMonteCarloTree` (bool, default False)
+- `keepAllSingleObjectCandsInMC` — store all single-object J/ψ, Υ, φ candidates and RecoKaonTrack block (default False)
+- `skipCompositeCandBuildingWhenKeepingSingles` — skip `combineCandidates()` after storing singles (default False)
+- `requireAcceptedCandidatesForMonteCarloTree` — only fill TTree entries with ≥1 accepted candidate (default False)
+
+### Multi-threading (VarParsing CLI)
+
+- `numThreads` / `numStreams` — CMSSW multi-threading (default: 1 / 0=auto)
 
 ### Analysis Modes
 
@@ -94,9 +121,14 @@ The main TTree (`X_One_Tree`) stores:
 - Primary vertex: position, errors, χ², beamspot-corrected variants
 - All muons: kinematics, ID flags, impact parameters, trigger matching
 - Resonance candidates (J/ψ, Υ, φ): mass, cτ, vertex prob, momentum (with uncertainties)
+- Kaon daughters of φ (`Phi_K_1_*`, `Phi_K_2_*`): per-track kinematics, PV diagnostics
+- `Phi_K_*_RecoKaonTrackIdx`: indices linking φ daughters to the flat RecoKaonTrack block
+- Single-object MC branches (`SingleJpsi_*`, `SingleUps_*`, `SinglePhi_*`): per-candidate kinematics, GEN-matching, daughter indices
+- `SinglePhi_K*_RecoKaonTrackIdx`: indices linking single-φ daughters to the RecoKaonTrack block
+- RecoKaonTrack block (`RecoKaonTrack_*`): flat per-track storage of (GEN-matched quality kaons) ∪ (φ-candidate daughters), with PV diagnostics, GEN-matching, and `usedInSinglePhi` flag
 - 3-body primary vertex: combined fit results
-- MC gen-level (MC_GenPart_*): flat storage of all relevant gen particles
-- Legacy MC branches (MC_X_*, MC_Dau_*): kept for backward compatibility
+- MC gen-level (`MC_GenPart_*`): flat storage of all relevant gen particles
+- Legacy MC branches (`MC_X_*`, `MC_Dau_*`): kept for backward compatibility
 
 ### Global Tag Selection
 
@@ -115,8 +147,12 @@ The main TTree (`X_One_Tree`) stores:
 ### Naming Conventions
 - Resonance candidates: `Jpsi_1_*`, `Jpsi_2_*`, `Ups_*`, `Phi_*` (suffixes: mass, ctau, px/py/pz, pt/eta/phi)
 - Muon indices: `Jpsi_1_mu_1_Idx`, `Jpsi_1_mu_2_Idx` (links muons to resonances)
-- Kaon indices: `Phi_K_1_Idx`, `Phi_K_2_Idx` (links kaons to φ)
+- Kaon indices: `Phi_K_1_Idx`, `Phi_K_2_Idx` (links kaons to φ, raw nonMuonTrack_ index)
+- Kaon RecoKaonTrack indices: `Phi_K_1_RecoKaonTrackIdx`, `SinglePhi_K1_RecoKaonTrackIdx` (links into `RecoKaonTrack_*` block)
+- Single-object candidates: `SingleJpsi_*`, `SingleUps_*`, `SinglePhi_*` (all-store MC efficiency branches)
 - Uncertainties: `*_pxErr`, `*_pyErr`, `*_pzErr`, `*_ptErr`
+- RecoKaonTrack block: `RecoKaonTrack_*` (flat per-track storage, used for phi/kaon efficiency)
+- Counter branches: `nRecoKaonTrack`, `nSingleJpsiCand`, `nSingleUpsCand`, `nSinglePhiCand`
 
 ### Adding New Branches
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,15 @@ cmsenv
 scram b -j 4
 ```
 
+### Validation Testing
+
+Follow the procedure in `doc/Validation_Test_Plan.md`. Key points:
+
+- Always `cmsenv` before running. Output files get a `_numEvent<N>` suffix when `maxEvents` is set.
+- The TTree is `X_data` inside a `TDirectoryFile` named `mkcands` — use `f.Get("mkcands").Get("X_data")` in ROOT.
+- Count candidates via vector lengths (e.g., `len(Pri_mass)`), not non-existent `nPriCand` branches.
+- Metric reference: 50-event JpsiJpsiPhi MC → 14/16 SingleJpsi, 33/90 SinglePhi, 0/0 SingleUps, 1/2 Pri (composite mode).
+
 ### Running Locally
 ```bash
 # Data (with era-specific global tag)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For each φ candidate:
 ### Single-Object Candidates (MC only, `KeepAllSingleObjectCandsInMC=True`)
 - `SingleJpsi_*`: Per-candidate J/ψ kinematics, vertex fit, GEN-matching, muon daughter indices
 - `SingleUps_*`: Per-candidate Υ kinematics, vertex fit, GEN-matching, muon daughter indices
-- `SinglePhi_*`: Per-candidate φ kinematics, vertex fit, GEN-matching, kaon daughter indices (`nonMuonTrackIdx` + `RecoKaonTrackIdx`)
+- `SinglePhi_*`: Per-candidate φ kinematics, vertex fit, GEN-matching, kaon daughter indices (`RecoKaonTrackIdx`)
 - Counters: `nSingleJpsiCand`, `nSingleUpsCand`, `nSinglePhiCand`
 
 ### RecoKaonTrack Block (MC only, `KeepAllSingleObjectCandsInMC=True`)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All selection cuts are externalized and can be changed **without recompilation**
 
 ```python
 MuonSelection  = cms.untracked.string("pt > 2.5 && abs(eta) < 2.4")
-TrackSelection = cms.untracked.string("pt > 2.0 && abs(eta) < 2.5 && numberOfHits > 4")
+TrackSelection = cms.untracked.string("pt > 1.0 && abs(eta) < 2.5 && numberOfHits > 4")
 ```
 
 These accept any valid expression on `pat::Muon` or `pat::PackedCandidate` members.
@@ -27,12 +27,12 @@ These accept any valid expression on `pat::Muon` or `pat::PackedCandidate` membe
 
 | Parameter     | Default | Description                     |
 |---------------|---------|---------------------------------|
-| `JpsiMassMin` | 1.0    | J/ψ dimuon mass lower bound     |
-| `JpsiMassMax` | 4.0    | J/ψ dimuon mass upper bound     |
-| `UpsMassMin`  | 8.0    | Υ dimuon mass lower bound       |
-| `UpsMassMax`  | 12.0   | Υ dimuon mass upper bound       |
-| `PhiMassMin`  | 0.8    | φ(→KK) mass lower bound         |
-| `PhiMassMax`  | 1.2    | φ(→KK) mass upper bound         |
+| `JpsiMassMin` | 2.8     | J/ψ dimuon mass lower bound     |
+| `JpsiMassMax` | 3.3     | J/ψ dimuon mass upper bound     |
+| `UpsMassMin`  | 8.0     | Υ dimuon mass lower bound       |
+| `UpsMassMax`  | 12.0    | Υ dimuon mass upper bound       |
+| `PhiMassMin`  | 0.97    | φ(→KK) mass lower bound         |
+| `PhiMassMax`  | 1.07    | φ(→KK) mass upper bound         |
 
 ### Primary Vertex Cuts
 
@@ -46,8 +46,45 @@ These accept any valid expression on `pat::Muon` or `pat::PackedCandidate` membe
 
 | Parameter             | Default | Description                          |
 |-----------------------|---------|--------------------------------------|
-| `OniaDecayVtxProbCut` | 0.001   | Minimum vertex prob for dimuon fits  |
-| `PriVtxProbCut`       | 0.0     | Minimum vertex prob for primary vtx  |
+| `OniaDecayVtxProbCut` | 5e-4    | Minimum vertex prob for dimuon fits  |
+| `PriVtxProbCut`       | -1.0    | Minimum vertex prob for primary vtx (negative = disabled) |
+
+### Candidate pT/η Pre-cuts
+
+| Parameter        | Default | Description                          |
+|------------------|---------|--------------------------------------|
+| `JpsiCandPtMin`  | 4.0     | J/ψ candidate minimum pT (GeV)       |
+| `JpsiCandEtaMax` | 999.0   | J/ψ candidate maximum |η|           |
+| `UpsCandPtMin`   | 4.0     | Υ candidate minimum pT (GeV)         |
+| `UpsCandEtaMax`  | 999.0   | Υ candidate maximum |η|             |
+| `PhiCandPtMin`   | 2.0     | φ candidate minimum pT (GeV)         |
+| `PhiCandEtaMax`  | 999.0   | φ candidate maximum |η|             |
+
+### Vertex Fit Toggles
+
+| Parameter          | Default | Description                        |
+|--------------------|---------|------------------------------------|
+| `DoJpsiDecayVtxFit` | True   | Enable J/ψ decay-vertex fit       |
+| `DoUpsDecayVtxFit`  | True   | Enable Υ decay-vertex fit         |
+| `DoPhiDecayVtxFit`  | True   | Enable φ decay-vertex fit         |
+| `DoDiOniaVtxFit`    | True   | Enable DiOnia common-vertex fit   |
+| `DoPriVtxFit`       | True   | Enable 3-body primary-vertex fit  |
+
+### MC Control (VarParsing CLI-only)
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `runOnMC` | False   | Enable `DoMonteCarloTree` + MC branches |
+| `keepAllSingleObjectCandsInMC` | False | Store all single-resonance candidates + RecoKaonTrack block |
+| `skipCompositeCandBuildingWhenKeepingSingles` | False | Skip final combineCandidates when storing singles |
+| `requireAcceptedCandidatesForMonteCarloTree` | False | Only fill TTree entries with ≥1 accepted candidate |
+
+### Multi-threading
+
+| Parameter    | Default | Description |
+|-------------|---------|-------------|
+| `numThreads` | 1       | Number of threads |
+| `numStreams` | 0       | Number of streams (0 = automatic) |
 
 ## New Branches (vs. previous version)
 
@@ -55,6 +92,32 @@ These accept any valid expression on `pat::Muon` or `pat::PackedCandidate` membe
 For each resonance (`Jpsi_1`, `Jpsi_2`, `Phi`, `Pri`):
 - `*_pxErr`, `*_pyErr`, `*_pzErr`: Component errors from `KinematicParametersError`
 - `*_ptErr`: Propagated transverse momentum error
+
+### Kaon Daughter Branches
+For each φ candidate:
+- `Phi_K_1_*`, `Phi_K_2_*`: Per-kaon kinematics, PV diagnostics, vertex ID
+- `Phi_K_1_RecoKaonTrackIdx`, `Phi_K_2_RecoKaonTrackIdx`: Indices into the RecoKaonTrack block (`-1` = not in block)
+
+### Single-Object Candidates (MC only, `KeepAllSingleObjectCandsInMC=True`)
+- `SingleJpsi_*`: Per-candidate J/ψ kinematics, vertex fit, GEN-matching, muon daughter indices
+- `SingleUps_*`: Per-candidate Υ kinematics, vertex fit, GEN-matching, muon daughter indices
+- `SinglePhi_*`: Per-candidate φ kinematics, vertex fit, GEN-matching, kaon daughter indices (`nonMuonTrackIdx` + `RecoKaonTrackIdx`)
+- Counters: `nSingleJpsiCand`, `nSingleUpsCand`, `nSinglePhiCand`
+
+### RecoKaonTrack Block (MC only, `KeepAllSingleObjectCandsInMC=True`)
+Lightweight flat per-track storage for phi/kaon efficiency. Contains the union of:
+1. GEN-matched tracks passing the full track quality filter (same cuts as `pairTracks()`)
+2. All kaon daughters from `KPairCand_Meson_` (φ candidates)
+
+Branches (`RecoKaonTrack_*`):
+- `nonMuonTrackIdx`: Cross-reference into `nonMuonTrack_`
+- `pt, eta, phi, px, py, pz, charge`: Track kinematics
+- `fromPV, pvAssocQuality, vertexId`: PV association
+- `dzPV, dxyPV, dzAssocPV, dxyAssocPV`: Impact parameters
+- `passDzPV, passDxyPV, passTrackPV`: Track quality flags
+- `genMatchIdx, genMatchSource, genMatchChi2`: GEN-level matching
+- `usedInSinglePhi`: 1 if track is a φ-candidate daughter
+- Counter: `nRecoKaonTrack`
 
 ### MC Gen-level (flat storage)
 - `MC_GenPart_pdgId`, `MC_GenPart_status`, `MC_GenPart_motherPdgId`

--- a/doc/Efficiency_Evaluation_Guideline.md
+++ b/doc/Efficiency_Evaluation_Guideline.md
@@ -44,18 +44,18 @@ Used for: HLT, four-muon vertexing, triOnia vertexing steps.
 
 ## 2. Branch-to-step mapping
 
-### 2.1 Acceptance — A_{J/ψ}, A_{φ}
+### 2.1 Acceptance — $A_{J/\psi}$, $A_{\phi}$
 
 The only step with an unconditional denominator. GEN-level, no RECO needed.
 
-**J/ψ acceptance** — A_{J/ψ}(pT, |y|):
+**$J/\psi$ acceptance** — $A_{J/\psi}(p_T, |y|)$:
 
 | Role | Logic |
 |------|-------|
 | Denominator | GEN J/ψ in kinematic acceptance: `MC_GenPart_pdgId == 443` and `abs(MC_GenPart_pdgId[mother]) != 443` (direct J/ψ, not feed-down) |
 | Numerator | Denominator J/ψ where both GEN daughter muons are in fiducial region: `MC_GenPart_pdgId == 13` or `-13` with mother = the GEN J/ψ, passing fiducial μ cuts (pT, η) |
 
-**φ acceptance** — A_{φ}(pT, |y|):
+**$\phi$ acceptance** — $A_{\phi}(p_T, |y|)$:
 
 | Role | Logic |
 |------|-------|
@@ -69,7 +69,7 @@ particle ordering (daughter follows mother in the GEN record). The
 `processMCGenInfo()` but not persisted to the TTree) are not needed here —
 work directly with the flat `MC_GenPart_*` vectors.
 
-### 2.2 muonRECO — ε_{μReco|J/ψ}
+### 2.2 muonRECO — $\varepsilon_{\mu\mathrm{Reco}|J/\psi}$
 
 | Role | Branch / logic |
 |------|----------------|
@@ -86,7 +86,7 @@ into `MC_GenPart_*`.
 The RECO-level matching for muons uses the configurable `RecoGenMuonMatchChi2Max`
 (default 25.0). Muons without a valid GEN match have `genMatchIdx = -1`.
 
-### 2.3 kaonRECO — ε_{KReco|φ}
+### 2.3 kaonRECO — $\varepsilon_{K\mathrm{Reco}|\phi}$
 
 | Role | Branch / logic |
 |------|----------------|
@@ -105,7 +105,7 @@ Alternatively, work entirely through the `RecoKaonTrack` block: iterate
 `RecoKaonTrack_*` entries with `genMatchIdx >= 0`, group by event, and check
 whether both GEN-matched kaons from a given φ are present.
 
-### 2.4 muonID — ε_{μID|J/ψ}
+### 2.4 muonID — $\varepsilon_{\mu\mathrm{ID}|J/\psi}$
 
 | Role | Branch / logic |
 |------|----------------|
@@ -119,7 +119,7 @@ Available muon ID flags: `muIsGoodTightMuon`, `muIsPatTightMuon`, `muIsPatMedium
 The baseline ID working point is **soft muon**: `muIsPatSoftMuon`. The working
 point is analysis-configurable and can be tightened in post-processing.
 
-### 2.5 kaonID — ε_{KID|φ}
+### 2.5 kaonID — $\varepsilon_{K\mathrm{ID}|\phi}$
 
 | Role | Branch / logic |
 |------|----------------|
@@ -135,7 +135,7 @@ analysis-configurable. PV-compatibility flags (`RecoKaonTrack_passDzPV`,
 `RecoKaonTrack_passDxyPV`, `RecoKaonTrack_passTrackPV`, `RecoKaonTrack_fromPV`)
 are reserved for the dikaon and triOnia vertexing steps below.
 
-### 2.6 dimuon — ε_{μμ|J/ψ}
+### 2.6 dimuon — $\varepsilon_{\mu\mu|J/\psi}$
 
 | Role | Branch / logic |
 |------|----------------|
@@ -148,7 +148,7 @@ mass window is already applied in `pairMuons()`; `SingleJpsi_mass` is the
 post-fit mass. Alternative or additional vertexing criteria may be applied
 depending on the analysis working point.
 
-### 2.7 dikaon — ε_{KK|φ}
+### 2.7 dikaon — $\varepsilon_{KK|\phi}$
 
 | Role | Branch / logic |
 |------|----------------|
@@ -161,7 +161,7 @@ mass window is already applied in `pairTracks()`. Alternative or additional
 vertexing criteria (e.g., `SinglePhi_trackPVPass`, `SinglePhi_commonAssocPVPass`)
 may be applied depending on the analysis working point.
 
-### 2.8 HLT — ε_{HLT}
+### 2.8 HLT — $\varepsilon_{\mathrm{HLT}}$
 
 | Role | Branch / logic |
 |------|----------------|
@@ -211,7 +211,7 @@ matching — it only indicates the trigger fired for the event, not that a
 specific muon was responsible. Use `muJpsiMatchedTriggerIndices` for the
 per-muon association.
 
-### 2.9 four-muon vertexing — ε_{4μvtx}
+### 2.9 four-muon vertexing — $\varepsilon_{4\mu\mathrm{vtx}}$
 
 | Role | Branch / logic |
 |------|----------------|
@@ -224,11 +224,11 @@ fit converged and passes the vertex probability cut (`DiOniaVtxProbCut`).
 Alternative or additional criteria (e.g., `DiOnia_commonRecVtxPass`) may be
 applied depending on the analysis working point.
 
-### 2.10 triOnia — ε_{triOnia}
+### 2.10 triOnia — $\varepsilon_{\mathrm{triOnia}}$
 
 | Role | Branch / logic |
 |------|----------------|
-| Denominator (passed four-muon vertexing) | Events passing four-muon vertexing (ε_{4μvtx} numerator), split by φ pT bins |
+| Denominator (passed four-muon vertexing) | Events passing four-muon vertexing ($\varepsilon_{4\mu\mathrm{vtx}}$ numerator), split by φ pT bins |
 | Numerator (passes THIS step) | Denominator events passing the chosen triOnia endpoint |
 
 The code produces four parallel quality flags for the three-meson primary vertex:
@@ -286,34 +286,34 @@ Use `maxEvents=-1` to process all events.
 
 ### Step 2: Build per-object efficiency maps
 
-Each efficiency is conditional: ε_step = N(pass step) / N(pass previous step).
+Each efficiency is conditional: $\varepsilon_{\mathrm{step}} = N(\text{pass step}) \;/\; N(\text{pass previous step})$.
 For each J/ψ and φ kinematic bin `(pT, |y|)`:
 
-1. **Acceptance** — A_{J/ψ}, A_{φ}: From `MC_GenPart_*`.
+1. **Acceptance** — $A_{J/\psi}$, $A_{\phi}$: From `MC_GenPart_*`.
    - Denominator: all GEN J/ψ (or φ) in the kinematic bin.
    - Numerator: denominator mesons where both GEN daughters are in the fiducial region.
 
-2. **muonRECO** — ε_{μReco|J/ψ}: From `SingleJpsi_*` (Run A).
+2. **muonRECO** — $\varepsilon_{\mu\mathrm{Reco}|J/\psi}$: From `SingleJpsi_*` (Run A).
    - Denominator: `SingleJpsi` where both GEN daughters are in fiducial acceptance.
    - Numerator: denominator candidates with both `mu*_genMatchIdx >= 0`.
 
-3. **kaonRECO** — ε_{KReco|φ}: From `SinglePhi_*` (Run A).
+3. **kaonRECO** — $\varepsilon_{K\mathrm{Reco}|\phi}$: From `SinglePhi_*` (Run A).
    - Denominator: `SinglePhi` where both GEN daughters are in fiducial acceptance.
    - Numerator: denominator candidates with both `K*_genMatchIdx >= 0`.
 
-4. **muonID** — ε_{μID|J/ψ}: From `SingleJpsi_*` + `mu*` (Run A).
+4. **muonID** — $\varepsilon_{\mu\mathrm{ID}|J/\psi}$: From `SingleJpsi_*` + `mu*` (Run A).
    - Denominator: `SingleJpsi` passing muonRECO (both muons GEN-matched).
    - Numerator: denominator candidates where both daughter muons pass the chosen ID (baseline: `muIsPatSoftMuon`).
 
-5. **kaonID** — ε_{KID|φ}: From `SinglePhi_*` + `RecoKaonTrack_*` (Run A).
+5. **kaonID** — $\varepsilon_{K\mathrm{ID}|\phi}$: From `SinglePhi_*` + `RecoKaonTrack_*` (Run A).
    - Denominator: `SinglePhi` passing kaonRECO (both kaons GEN-matched).
    - Numerator: denominator candidates where both daughter kaons pass the chosen track-quality ID.
 
-6. **dimuon** — ε_{μμ|J/ψ}: From `SingleJpsi_*` (Run A).
+6. **dimuon** — $\varepsilon_{\mu\mu|J/\psi}$: From `SingleJpsi_*` (Run A).
    - Denominator: `SingleJpsi` passing muonID.
    - Numerator: denominator candidates with `SingleJpsi_fitValid && SingleJpsi_fitPass`.
 
-7. **dikaon** — ε_{KK|φ}: From `SinglePhi_*` (Run A).
+7. **dikaon** — $\varepsilon_{KK|\phi}$: From `SinglePhi_*` (Run A).
    - Denominator: `SinglePhi` passing kaonID.
    - Numerator: denominator candidates with `SinglePhi_fitValid && SinglePhi_fitPass`.
 
@@ -321,15 +321,15 @@ For each J/ψ and φ kinematic bin `(pT, |y|)`:
 
 From the full chain ntuple (Run B):
 
-1. **HLT** — ε_{HLT}:
+1. **HLT** — $\varepsilon_{\mathrm{HLT}}$:
    - Denominator: events with ≥1 valid dimuon candidate.
    - Numerator: denominator events where `MatchJpsiTriggerNames` is non-empty AND at least one daughter muon of the candidate has non-empty `muJpsiMatchedTriggerIndices`.
 
-2. **four-muon vertexing** — ε_{4μvtx}: From `DiOnia_*` (Run B).
+2. **four-muon vertexing** — $\varepsilon_{4\mu\mathrm{vtx}}$: From `DiOnia_*` (Run B).
    - Denominator: events passing HLT + trigger matching, with valid dimuon pairs in both J/ψ slots.
    - Numerator: denominator events with `DiOnia_fitValid && DiOnia_fitPass`.
 
-3. **triOnia** — ε_{triOnia}: From `Pri_*` (Run B), split by φ pT bins.
+3. **triOnia** — $\varepsilon_{\mathrm{triOnia}}$: From `Pri_*` (Run B), split by φ pT bins.
    - Denominator: events passing four-muon vertexing.
    - Numerator: denominator events passing the chosen endpoint (default: `Pri_assocPVPass`).
 

--- a/doc/Efficiency_Evaluation_Guideline.md
+++ b/doc/Efficiency_Evaluation_Guideline.md
@@ -1,0 +1,334 @@
+# Efficiency and Acceptance Evaluation Guideline
+
+Maps the factorized efficiency scheme in `Efficiency_scheme.md` to the current
+ntuple branch structure and configuration system.
+
+---
+
+## 1. Required MC runs
+
+Two configurations are needed, both from `ConfFile_cfg.py`:
+
+### Run A — Object-level (singles only)
+
+```bash
+cmsRun ConfFile_cfg.py \
+    analysisMode=JpsiJpsiPhi \
+    inputFiles=file:myMC.root \
+    outputFile=eff_singles.root \
+    runOnMC=True era=Run2022 \
+    keepAllSingleObjectCandsInMC=True \
+    skipCompositeCandBuildingWhenKeepingSingles=True
+```
+
+Provides: `SingleJpsi_*`, `SinglePhi_*`, `RecoKaonTrack_*`, `MC_GenPart_*`.
+Used for: acceptance, muonRECO, kaonRECO, muonID, kaonID, dimuon, dikaon steps.
+
+Use **loose object-level cuts** so that denominator populations are not cut away
+before efficiency evaluation. The tight defaults (`JpsiCandPtMin=4.0`,
+`PhiCandPtMin=2.0`) will bias your denominators. Either pass loose values on the
+command line (not available via VarParsing for these parameters) or maintain a
+loose-cut config variant with `JpsiCandPtMin=0.0`, `PhiCandPtMin=0.0`,
+`JpsiMassMin=1.0`, `JpsiMassMax=4.0`, `PhiMassMin=0.8`, `PhiMassMax=1.2`.
+
+### Run B — Full chain (singles + composite)
+
+```bash
+cmsRun ConfFile_cfg.py \
+    analysisMode=JpsiJpsiPhi \
+    inputFiles=file:myMC.root \
+    outputFile=eff_fullchain.root \
+    runOnMC=True era=Run2022 \
+    keepAllSingleObjectCandsInMC=True \
+    skipCompositeCandBuildingWhenKeepingSingles=False
+```
+
+Provides: all of Run A plus `Jpsi_1_*`, `Jpsi_2_*`, `Phi_*`, `DiOnia_*`, `Pri_*`,
+`Phi_K_*_RecoKaonTrackIdx`, HLT/trigger branches.
+Used for: HLT, four-muon vertexing, triOnia vertexing steps.
+
+---
+
+## 2. Branch-to-step mapping
+
+### 2.1 Acceptance (GEN-level, no RECO needed)
+
+| Quantity | Branch / logic |
+|----------|---------------|
+| GEN J/ψ in acceptance | `MC_GenPart_pdgId == 443` and `abs(MC_GenPart_pdgId[mother]) != 443` (direct J/ψ, not feed-down). Apply generator-level pT/rapidity cuts. |
+| GEN φ in acceptance | `MC_GenPart_pdgId == 333` (direct φ). Same logic. |
+| GEN μ from J/ψ | `MC_GenPart_pdgId == 13` or `-13`, mother is the GEN J/ψ. Apply fiducial μ cuts (pT, η). |
+| GEN K from φ | `MC_GenPart_pdgId == 321`, mother is the GEN φ. Apply fiducial K cuts. |
+
+Numerator: events where both GEN daughters pass fiducial cuts.
+Denominator: events with GEN J/ψ (or φ) in the kinematic acceptance.
+
+The `MC_GenPart_*` branches store all relevant GEN particles in flat vectors.
+Use the mother-daughter linking via `MC_GenPart_motherPdgId` and the stored
+particle ordering (daughter follows mother in the GEN record). The
+`handleToNtupleIndex_` / `ntupleToHandleIndex_` maps (populated in
+`processMCGenInfo()` but not persisted to the TTree) are not needed here —
+work directly with the flat `MC_GenPart_*` vectors.
+
+### 2.2 muonRECO — both daughter muons reconstructed and matched
+
+| Quantity | Branch |
+|----------|--------|
+| RECO muons matched to GEN J/ψ daughters | For each `SingleJpsi` candidate: `SingleJpsi_mu1_genMatchIdx >= 0` AND `SingleJpsi_mu2_genMatchIdx >= 0` |
+| Denominator | `SingleJpsi` candidates where both GEN daughter muons are in fiducial acceptance (cross-reference `MC_GenPart_*` via the stored daughter PDG IDs) |
+
+The `SingleJpsi_*` branches are filled **before** the final `JpsiCandPtMin` /
+`JpsiCandEtaMax` cuts in `pairMuons()`, so they capture all dimuon pairs that
+survive the mass window and vertex fit. The `SingleJpsi_mu1_Idx` /
+`SingleJpsi_mu2_Idx` give indices into the `mu*` branches for the daughter
+muons; `SingleJpsi_mu1_genMatchIdx` / `SingleJpsi_mu2_genMatchIdx` are indices
+into `MC_GenPart_*`.
+
+The RECO-level matching for muons uses the configurable `RecoGenMuonMatchChi2Max`
+(default 25.0). Muons without a valid GEN match have `genMatchIdx = -1`.
+
+### 2.3 kaonRECO — both daughter kaons reconstructed and matched
+
+| Quantity | Branch |
+|----------|--------|
+| RECO kaons matched to GEN φ daughters | For each `SinglePhi` candidate: `SinglePhi_K1_genMatchIdx >= 0` AND `SinglePhi_K2_genMatchIdx >= 0` |
+| Denominator | `SinglePhi` candidates where both GEN daughter kaons are in fiducial acceptance |
+
+The `SinglePhi_K1_RecoKaonTrackIdx` / `SinglePhi_K2_RecoKaonTrackIdx` give indices
+into `RecoKaonTrack_*` for the daughter kaons, which contains the GEN-match
+information (`RecoKaonTrack_genMatchIdx`).
+
+The RECO-level matching for kaons uses `RecoGenKaonMatchChi2Max` (default 25.0).
+
+Alternatively, work entirely through the `RecoKaonTrack` block: iterate
+`RecoKaonTrack_*` entries with `genMatchIdx >= 0`, group by event, and check
+whether both GEN-matched kaons from a given φ are present.
+
+### 2.4 muonID — both matched muons pass ID
+
+| Quantity | Branch |
+|----------|--------|
+| Muon ID flags | `muIsGoodTightMuon`, `muIsPatTightMuon`, `muIsPatMediumMuon`, `muIsPatSoftMuon`, `muIsGlobalMuon` |
+| Per-J/ψ daughter indices | `SingleJpsi_mu1_Idx`, `SingleJpsi_mu2_Idx` — use these to look up the muon block |
+
+The specific ID working point is analysis-dependent. A typical tight-muon
+definition checks `muIsGoodTightMuon && muIsGlobalMuon`. Apply the ID selection
+to both daughter muons of the J/ψ candidate.
+
+Denominator: `SingleJpsi` candidates passing muonRECO (both muons GEN-matched).
+
+### 2.5 kaonID — both matched kaons pass track quality
+
+| Quantity | Branch |
+|----------|--------|
+| Kaon track quality | `RecoKaonTrack_passDzPV`, `RecoKaonTrack_passDxyPV`, `RecoKaonTrack_passTrackPV`, `RecoKaonTrack_fromPV` |
+| Per-φ daughter RecoKaonTrack indices | `SinglePhi_K1_RecoKaonTrackIdx`, `SinglePhi_K2_RecoKaonTrackIdx` |
+
+The `RecoKaonTrack_*` block stores the same quality flags used in `pairTracks()`
+for both GEN-matched tracks and φ-candidate daughters. Look up the daughter's
+`RecoKaonTrack_*` entry via the `RecoKaonTrackIdx` and check the quality flags.
+
+Denominator: `SinglePhi` candidates passing kaonRECO (both kaons GEN-matched).
+
+### 2.6 dimuon — valid J/ψ dimuon candidate
+
+| Quantity | Branch |
+|----------|--------|
+| Vertex fit valid | `SingleJpsi_fitValid > 0` |
+| Vertex fit passes prob cut | `SingleJpsi_fitPass > 0` (respects `JpsiDecayVtxProbCut`) |
+| Mass window | Already applied in `pairMuons()`; `SingleJpsi_mass` is the post-fit mass |
+
+A "valid dimuon candidate" is one where `fitValid && fitPass && massDiff` is
+within acceptable range. The `SingleJpsi_massDiff` branch stores the difference
+between pre-fit and post-fit mass.
+
+Denominator: `SingleJpsi` candidates passing muonID.
+
+### 2.7 dikaon — valid φ → K⁺K⁻ candidate
+
+| Quantity | Branch |
+|----------|--------|
+| Vertex fit valid | `SinglePhi_fitValid > 0` |
+| Vertex fit passes prob cut | `SinglePhi_fitPass > 0` (respects `PhiDecayVtxProbCut`) |
+| Mass window | Already applied in `pairTracks()`; `SinglePhi_mass` is the post-fit mass |
+| Common PV association | `SinglePhi_commonAssocPVPass` |
+| Track PV compatibility | `SinglePhi_trackPVPass` |
+
+Denominator: `SinglePhi` candidates passing kaonID.
+
+### 2.8 HLT — trigger OR of J/ψ triggers
+
+| Quantity | Branch |
+|----------|--------|
+| Event-level trigger decisions | `trigRes` (HLT results), `trigNames` (HLT path names) |
+| J/ψ trigger matching | `MatchJpsiTriggerNames` (which J/ψ trigger paths matched), `muIsJpsiTrigMatch` (per-muon trigger match) |
+| J/ψ filter matching | `muIsJpsiFilterMatch` |
+
+The HLT step requires at least one of the configured J/ψ trigger paths to fire
+AND have trigger-object matching to the candidate muons.
+
+Denominator: events with at least one valid `Jpsi_1` candidate (from the full
+chain ntuple, Run B).
+
+### 2.9 four-muon vertexing — valid J/ψ J/ψ vertex
+
+| Quantity | Branch |
+|----------|--------|
+| DiOnia fit valid | `DiOnia_fitValid > 0` |
+| DiOnia fit passes prob cut | `DiOnia_fitPass > 0` (respects `DiOniaVtxProbCut`) |
+| Common reco-vertex check | `DiOnia_commonRecVtxPass > 0` |
+
+This step combines the two J/ψ candidates into a common vertex. It requires both
+`Jpsi_1` and `Jpsi_2` branches from the full chain ntuple (Run B).
+
+Denominator: events passing HLT with at least one valid dimuon pair for each of
+the two J/ψ slots.
+
+### 2.10 triOnia — final three-meson vertex + event-level cuts
+
+| Quantity | Branch |
+|----------|--------|
+| Primary vertex fit valid | `Pri_fitValid > 0` |
+| Primary vertex fit passes prob cut | `Pri_fitPass > 0` (respects `PriVtxProbCut`) |
+| Common PV association | `Pri_assocPVPass > 0` |
+| Track PV compatibility | `Pri_trackPVPass > 0` |
+| Final mass check | Internal (`CheckFinalMass` flag) |
+
+The code produces four parallel quality flags for the primary vertex. The
+default endpoint for corrected-yield studies is `Pri_assocPVPass / four_muon_vtx`
+as noted in `Efficiency_scheme.md`.
+
+Denominator: events passing four-muon vertexing, split by φ pT bins.
+
+---
+
+## 3. Configuration considerations
+
+### 3.1 Cuts that must be loose for denominator studies
+
+The following cuts are applied **before** single-object branches are filled and
+cannot be undone downstream. They must be set loosely for efficiency denominator
+evaluation:
+
+| Parameter | Tight default | Recommended loose |
+|-----------|--------------|-------------------|
+| `JpsiMassMin` / `JpsiMassMax` | 2.8 / 3.3 | 1.0 / 4.0 |
+| `PhiMassMin` / `PhiMassMax` | 0.97 / 1.07 | 0.8 / 1.2 |
+| `OniaDecayVtxProbCut` | 5e-4 | 0.0 (or keep) |
+| `JpsiDecayVtxProbCut` | 5e-4 | 0.0 (or keep) |
+| `PhiDecayVtxProbCut` | 5e-4 | 0.0 (or keep) |
+| `MuonSelection` | `pt > 2.5 && abs(eta) < 2.4` | Match your fiducial definition |
+| `TrackSelection` | `pt > 1.0 && abs(eta) < 2.5 && numberOfHits > 4` | Match your fiducial definition |
+
+These are hardcoded in `ConfFile_cfg.py` and not exposed via `VarParsing` (the
+`VarParsing` system only exposes the MC control switches, not the physics cut
+values). Maintain a separate loose-cut config file for efficiency studies, or
+override the values directly before `cmsRun`.
+
+### 3.2 Cuts you can tighten in post-processing
+
+| Parameter | Why post-processable |
+|-----------|---------------------|
+| `JpsiCandPtMin`, `JpsiCandEtaMax` | These are applied in `pairMuons()` as pre-cuts on the composite candidate. The `SingleJpsi_pt` branch records the value; you can apply any pT cut in analysis. |
+| `PhiCandPtMin`, `PhiCandEtaMax` | Same reasoning — `SinglePhi_pt` records the value. |
+| `MinTrackFromPV` | Recorded in `RecoKaonTrack_fromPV` and `SinglePhi_K*_fromPV`. |
+| Track `normalizedChi2`, `highPurity` | Recorded (indirectly) via `RecoKaonTrack_passTrackPV`. |
+
+### 3.3 MC control flags
+
+| Flag | Effect on efficiency evaluation |
+|------|--------------------------------|
+| `keepAllSingleObjectCandsInMC=True` | **Required** — enables `SingleJpsi_*`, `SinglePhi_*`, `RecoKaonTrack_*` |
+| `skipCompositeCandBuildingWhenKeepingSingles=True` | Optional — skips `combineCandidates()` for a smaller, faster ntuple when only per-object steps are needed |
+| `requireAcceptedCandidatesForMonteCarloTree=False` | Recommended for efficiency — keeps every event even when no candidate passes |
+
+### 3.4 Vertex fit toggles
+
+| Toggle | Default | Notes |
+|--------|---------|-------|
+| `DoJpsiDecayVtxFit` | True | Needed for `SingleJpsi_fitValid` |
+| `DoPhiDecayVtxFit` | True | Needed for `SinglePhi_fitValid` |
+| `DoDiOniaVtxFit` | True | Needed for `DiOnia_*` branches |
+| `DoPriVtxFit` | True | Needed for `Pri_*` branches |
+
+---
+
+## 4. Suggested analysis workflow
+
+### Step 1: Produce efficiency ntuples
+
+Run both Run A (singles-only) and Run B (full chain) with loose physics cuts on
+the full MC sample(s). Use `maxEvents=-1` to process all events.
+
+### Step 2: Build per-object efficiency maps
+
+For each J/ψ and φ kinematic bin `(pT, |y|)`:
+
+1. **Acceptance**: From `MC_GenPart_*`, count GEN J/ψ (or φ) in the bin.
+   Numerator: daughters in fiducial region. Denominator: all GEN J/ψ (or φ).
+   Output: `A_Jpsi(pT, |y|)`, `A_phi(pT, |y|)`.
+
+2. **muonRECO / kaonRECO**: From `SingleJpsi_*` / `SinglePhi_*` (Run A).
+   Numerator: candidates with both daughters `genMatchIdx >= 0`.
+   Denominator: candidates with both GEN daughters in fiducial acceptance.
+   Output: `eps_muReco(pT, |y|)`, `eps_kReco(pT, |y|)`.
+
+3. **muonID / kaonID**: From `SingleJpsi_*` + `mu*` / `SinglePhi_*` + `RecoKaonTrack_*`.
+   Numerator: RECO-passing candidates where both daughters pass ID.
+   Denominator: RECO-passing candidates.
+   Output: `eps_muID(pT, |y|)`, `eps_kID(pT, |y|)`.
+
+4. **dimuon / dikaon**: From `SingleJpsi_*` / `SinglePhi_*`.
+   Numerator: candidates with `fitValid && fitPass`.
+   Denominator: ID-passing candidates.
+   Output: `eps_mumu(pT, |y|)`, `eps_KK(pT, |y|)`.
+
+### Step 3: Build event-level efficiency maps
+
+From the full chain ntuple (Run B):
+
+1. **HLT**: Count events where trigger fired + trigger-object match exists.
+   Denominator: events with ≥1 valid dimuon candidate.
+
+2. **four-muon vertexing** (`eps_4muVtx`): From `DiOnia_*`.
+   Numerator: `DiOnia_fitValid && DiOnia_fitPass`.
+   Denominator: HLT-passing events.
+
+3. **triOnia** (`eps_triOnia`): From `Pri_*`, split by φ pT bins.
+   Numerator: `Pri_assocPVPass` (or chosen endpoint).
+   Denominator: four-muon-vertexing-passing events.
+
+### Step 4: Apply correction
+
+The per-event total efficiency weight is the product of all per-object and
+event-level factors evaluated at the event's kinematics, times the factorized
+acceptance. See `Efficiency_scheme.md` Section "Definitions" for the product
+formula.
+
+---
+
+## 5. Cross-checks
+
+### 5.1 Factorized vs. cumulative comparison
+
+Compare the factorized efficiency product against a direct "all steps pass"
+count on the full chain ntuple. Significant disagreement indicates correlations
+between the per-object steps that the factorized approach misses.
+
+### 5.2 RecoKaonTrack coverage
+
+Verify that every φ-candidate daughter has a `RecoKaonTrack_*` entry:
+`SinglePhi_K*_RecoKaonTrackIdx >= 0` for all `SinglePhi` candidates. A `-1`
+sentinel indicates a kaon track missing from the RecoKaonTrack block (should
+not happen when `KeepAllSingleObjectCandsInMC=True`).
+
+### 5.3 Bin-edge sensitivity
+
+Vary the fine/coarse bin thresholds (`N_min_fine`, `N_min_coarse`) and confirm
+the corrected yield is stable within MC statistical uncertainties.
+
+### 5.4 GEN-RECO daughter matching consistency
+
+For `SinglePhi` candidates, compare the direct GEN-match info
+(`SinglePhi_K1_genMatchIdx`) with the RecoKaonTrack-level match
+(`RecoKaonTrack_genMatchIdx[SinglePhi_K1_RecoKaonTrackIdx]`). They must agree.

--- a/doc/Efficiency_Evaluation_Guideline.md
+++ b/doc/Efficiency_Evaluation_Guideline.md
@@ -24,13 +24,6 @@ cmsRun ConfFile_cfg.py \
 Provides: `SingleJpsi_*`, `SinglePhi_*`, `RecoKaonTrack_*`, `MC_GenPart_*`.
 Used for: acceptance, muonRECO, kaonRECO, muonID, kaonID, dimuon, dikaon steps.
 
-Use **loose object-level cuts** so that denominator populations are not cut away
-before efficiency evaluation. The tight defaults (`JpsiCandPtMin=4.0`,
-`PhiCandPtMin=2.0`) will bias your denominators. Either pass loose values on the
-command line (not available via VarParsing for these parameters) or maintain a
-loose-cut config variant with `JpsiCandPtMin=0.0`, `PhiCandPtMin=0.0`,
-`JpsiMassMin=1.0`, `JpsiMassMax=4.0`, `PhiMassMin=0.8`, `PhiMassMax=1.2`.
-
 ### Run B — Full chain (singles + composite)
 
 ```bash
@@ -51,35 +44,41 @@ Used for: HLT, four-muon vertexing, triOnia vertexing steps.
 
 ## 2. Branch-to-step mapping
 
-### 2.1 Acceptance (GEN-level, no RECO needed)
+### 2.1 Acceptance — A_{J/ψ}, A_{φ}
 
-| Quantity | Branch / logic |
-|----------|---------------|
-| GEN J/ψ in acceptance | `MC_GenPart_pdgId == 443` and `abs(MC_GenPart_pdgId[mother]) != 443` (direct J/ψ, not feed-down). Apply generator-level pT/rapidity cuts. |
-| GEN φ in acceptance | `MC_GenPart_pdgId == 333` (direct φ). Same logic. |
-| GEN μ from J/ψ | `MC_GenPart_pdgId == 13` or `-13`, mother is the GEN J/ψ. Apply fiducial μ cuts (pT, η). |
-| GEN K from φ | `MC_GenPart_pdgId == 321`, mother is the GEN φ. Apply fiducial K cuts. |
+The only step with an unconditional denominator. GEN-level, no RECO needed.
 
-Numerator: events where both GEN daughters pass fiducial cuts.
-Denominator: events with GEN J/ψ (or φ) in the kinematic acceptance.
+**J/ψ acceptance** — A_{J/ψ}(pT, |y|):
+
+| Role | Logic |
+|------|-------|
+| Denominator | GEN J/ψ in kinematic acceptance: `MC_GenPart_pdgId == 443` and `abs(MC_GenPart_pdgId[mother]) != 443` (direct J/ψ, not feed-down) |
+| Numerator | Denominator J/ψ where both GEN daughter muons are in fiducial region: `MC_GenPart_pdgId == 13` or `-13` with mother = the GEN J/ψ, passing fiducial μ cuts (pT, η) |
+
+**φ acceptance** — A_{φ}(pT, |y|):
+
+| Role | Logic |
+|------|-------|
+| Denominator | GEN φ in kinematic acceptance: `MC_GenPart_pdgId == 333` (direct φ) |
+| Numerator | Denominator φ where both GEN daughter kaons are in fiducial region: `MC_GenPart_pdgId == 321` with mother = the GEN φ, passing fiducial K cuts |
 
 The `MC_GenPart_*` branches store all relevant GEN particles in flat vectors.
-Use the mother-daughter linking via `MC_GenPart_motherPdgId` and the stored
+Use mother-daughter linking via `MC_GenPart_motherPdgId` and the stored
 particle ordering (daughter follows mother in the GEN record). The
 `handleToNtupleIndex_` / `ntupleToHandleIndex_` maps (populated in
 `processMCGenInfo()` but not persisted to the TTree) are not needed here —
 work directly with the flat `MC_GenPart_*` vectors.
 
-### 2.2 muonRECO — both daughter muons reconstructed and matched
+### 2.2 muonRECO — ε_{μReco|J/ψ}
 
-| Quantity | Branch |
-|----------|--------|
-| RECO muons matched to GEN J/ψ daughters | For each `SingleJpsi` candidate: `SingleJpsi_mu1_genMatchIdx >= 0` AND `SingleJpsi_mu2_genMatchIdx >= 0` |
-| Denominator | `SingleJpsi` candidates where both GEN daughter muons are in fiducial acceptance (cross-reference `MC_GenPart_*` via the stored daughter PDG IDs) |
+| Role | Branch / logic |
+|------|----------------|
+| Denominator (passed acceptance) | `SingleJpsi` candidates where both GEN daughter muons are in fiducial acceptance (cross-reference `MC_GenPart_*` via daughter PDG IDs) |
+| Numerator (passes THIS step) | Denominator `SingleJpsi` where `SingleJpsi_mu1_genMatchIdx >= 0` AND `SingleJpsi_mu2_genMatchIdx >= 0` |
 
 The `SingleJpsi_*` branches are filled **before** the final `JpsiCandPtMin` /
 `JpsiCandEtaMax` cuts in `pairMuons()`, so they capture all dimuon pairs that
-survive the mass window and vertex fit. The `SingleJpsi_mu1_Idx` /
+survive the mass window and vertex fit. `SingleJpsi_mu1_Idx` /
 `SingleJpsi_mu2_Idx` give indices into the `mu*` branches for the daughter
 muons; `SingleJpsi_mu1_genMatchIdx` / `SingleJpsi_mu2_genMatchIdx` are indices
 into `MC_GenPart_*`.
@@ -87,145 +86,170 @@ into `MC_GenPart_*`.
 The RECO-level matching for muons uses the configurable `RecoGenMuonMatchChi2Max`
 (default 25.0). Muons without a valid GEN match have `genMatchIdx = -1`.
 
-### 2.3 kaonRECO — both daughter kaons reconstructed and matched
+### 2.3 kaonRECO — ε_{KReco|φ}
 
-| Quantity | Branch |
-|----------|--------|
-| RECO kaons matched to GEN φ daughters | For each `SinglePhi` candidate: `SinglePhi_K1_genMatchIdx >= 0` AND `SinglePhi_K2_genMatchIdx >= 0` |
-| Denominator | `SinglePhi` candidates where both GEN daughter kaons are in fiducial acceptance |
+| Role | Branch / logic |
+|------|----------------|
+| Denominator (passed acceptance) | `SinglePhi` candidates where both GEN daughter kaons are in fiducial acceptance |
+| Numerator (passes THIS step) | Denominator `SinglePhi` where `SinglePhi_K1_genMatchIdx >= 0` AND `SinglePhi_K2_genMatchIdx >= 0` |
 
-The `SinglePhi_K1_RecoKaonTrackIdx` / `SinglePhi_K2_RecoKaonTrackIdx` give indices
-into `RecoKaonTrack_*` for the daughter kaons, which contains the GEN-match
-information (`RecoKaonTrack_genMatchIdx`).
+`SinglePhi_K1_RecoKaonTrackIdx` / `SinglePhi_K2_RecoKaonTrackIdx` give indices
+into the `RecoKaonTrack_*` block (always populated from φ-candidate daughters).
+The `RecoKaonTrack_genMatchIdx` field mirrors the inline `SinglePhi_K*_genMatchIdx`
+— they must agree (see Section 5.4).
 
 The RECO-level matching for kaons uses `RecoGenKaonMatchChi2Max` (default 25.0).
+Kaons without a valid GEN match have `genMatchIdx = -1`.
 
 Alternatively, work entirely through the `RecoKaonTrack` block: iterate
 `RecoKaonTrack_*` entries with `genMatchIdx >= 0`, group by event, and check
 whether both GEN-matched kaons from a given φ are present.
 
-### 2.4 muonID — both matched muons pass ID
+### 2.4 muonID — ε_{μID|J/ψ}
 
-| Quantity | Branch |
-|----------|--------|
-| Muon ID flags | `muIsGoodTightMuon`, `muIsPatTightMuon`, `muIsPatMediumMuon`, `muIsPatSoftMuon`, `muIsGlobalMuon` |
-| Per-J/ψ daughter indices | `SingleJpsi_mu1_Idx`, `SingleJpsi_mu2_Idx` — use these to look up the muon block |
+| Role | Branch / logic |
+|------|----------------|
+| Denominator (passed muonRECO) | `SingleJpsi` candidates with both muons GEN-matched (muonRECO numerator) |
+| Numerator (passes THIS step) | Denominator `SingleJpsi` where both daughter muons pass the chosen ID working point |
 
-The specific ID working point is analysis-dependent. A typical tight-muon
-definition checks `muIsGoodTightMuon && muIsGlobalMuon`. Apply the ID selection
-to both daughter muons of the J/ψ candidate.
+Use `SingleJpsi_mu1_Idx` / `SingleJpsi_mu2_Idx` to look up the muon block.
+Available muon ID flags: `muIsGoodTightMuon`, `muIsPatTightMuon`, `muIsPatMediumMuon`,
+`muIsPatSoftMuon`, `muIsGlobalMuon`.
 
-Denominator: `SingleJpsi` candidates passing muonRECO (both muons GEN-matched).
+The baseline ID working point is **soft muon**: `muIsPatSoftMuon`. The working
+point is analysis-configurable and can be tightened in post-processing.
 
-### 2.5 kaonID — both matched kaons pass track quality
+### 2.5 kaonID — ε_{KID|φ}
 
-| Quantity | Branch |
-|----------|--------|
-| Kaon track quality | `RecoKaonTrack_passDzPV`, `RecoKaonTrack_passDxyPV`, `RecoKaonTrack_passTrackPV`, `RecoKaonTrack_fromPV` |
-| Per-φ daughter RecoKaonTrack indices | `SinglePhi_K1_RecoKaonTrackIdx`, `SinglePhi_K2_RecoKaonTrackIdx` |
+| Role | Branch / logic |
+|------|----------------|
+| Denominator (passed kaonRECO) | `SinglePhi` candidates with both kaons GEN-matched (kaonRECO numerator) |
+| Numerator (passes THIS step) | Denominator `SinglePhi` where both daughter kaons pass the chosen track-quality ID working point |
 
-The `RecoKaonTrack_*` block stores the same quality flags used in `pairTracks()`
-for both GEN-matched tracks and φ-candidate daughters. Look up the daughter's
-`RecoKaonTrack_*` entry via the `RecoKaonTrackIdx` and check the quality flags.
+Use `SinglePhi_K1_RecoKaonTrackIdx` / `SinglePhi_K2_RecoKaonTrackIdx` to look up
+the `RecoKaonTrack_*` block (always populated from φ-candidate daughters).
 
-Denominator: `SinglePhi` candidates passing kaonRECO (both kaons GEN-matched).
+The baseline kaon ID is the `TrackSelection` string cut applied at the input
+level (e.g., `pt > 1.0 && abs(eta) < 2.5 && numberOfHits > 4`). This is
+analysis-configurable. PV-compatibility flags (`RecoKaonTrack_passDzPV`,
+`RecoKaonTrack_passDxyPV`, `RecoKaonTrack_passTrackPV`, `RecoKaonTrack_fromPV`)
+are reserved for the dikaon and triOnia vertexing steps below.
 
-### 2.6 dimuon — valid J/ψ dimuon candidate
+### 2.6 dimuon — ε_{μμ|J/ψ}
 
-| Quantity | Branch |
-|----------|--------|
-| Vertex fit valid | `SingleJpsi_fitValid > 0` |
-| Vertex fit passes prob cut | `SingleJpsi_fitPass > 0` (respects `JpsiDecayVtxProbCut`) |
-| Mass window | Already applied in `pairMuons()`; `SingleJpsi_mass` is the post-fit mass |
+| Role | Branch / logic |
+|------|----------------|
+| Denominator (passed muonID) | `SingleJpsi` candidates where both muons pass the chosen ID (muonID numerator) |
+| Numerator (passes THIS step) | Denominator `SingleJpsi` where `SingleJpsi_fitValid > 0` AND `SingleJpsi_fitPass > 0` |
 
-A "valid dimuon candidate" is one where `fitValid && fitPass && massDiff` is
-within acceptable range. The `SingleJpsi_massDiff` branch stores the difference
-between pre-fit and post-fit mass.
+The baseline criterion for a valid dimuon candidate is that the kinematic vertex
+fit converged and passes the vertex probability cut (`JpsiDecayVtxProbCut`). The
+mass window is already applied in `pairMuons()`; `SingleJpsi_mass` is the
+post-fit mass. Alternative or additional vertexing criteria may be applied
+depending on the analysis working point.
 
-Denominator: `SingleJpsi` candidates passing muonID.
+### 2.7 dikaon — ε_{KK|φ}
 
-### 2.7 dikaon — valid φ → K⁺K⁻ candidate
+| Role | Branch / logic |
+|------|----------------|
+| Denominator (passed kaonID) | `SinglePhi` candidates where both kaons pass track-quality ID (kaonID numerator) |
+| Numerator (passes THIS step) | Denominator `SinglePhi` where `SinglePhi_fitValid > 0` AND `SinglePhi_fitPass > 0` |
 
-| Quantity | Branch |
-|----------|--------|
-| Vertex fit valid | `SinglePhi_fitValid > 0` |
-| Vertex fit passes prob cut | `SinglePhi_fitPass > 0` (respects `PhiDecayVtxProbCut`) |
-| Mass window | Already applied in `pairTracks()`; `SinglePhi_mass` is the post-fit mass |
-| Common PV association | `SinglePhi_commonAssocPVPass` |
-| Track PV compatibility | `SinglePhi_trackPVPass` |
+The baseline criterion for a valid dikaon candidate is that the kinematic vertex
+fit converged and passes the vertex probability cut (`PhiDecayVtxProbCut`). The
+mass window is already applied in `pairTracks()`. Alternative or additional
+vertexing criteria (e.g., `SinglePhi_trackPVPass`, `SinglePhi_commonAssocPVPass`)
+may be applied depending on the analysis working point.
 
-Denominator: `SinglePhi` candidates passing kaonID.
+### 2.8 HLT — ε_{HLT}
 
-### 2.8 HLT — trigger OR of J/ψ triggers
+| Role | Branch / logic |
+|------|----------------|
+| Denominator (passed per-object steps) | Events with at least one valid dimuon candidate (Run B, full chain) |
+| Numerator (passes THIS step) | Denominator events where at least one configured J/ψ trigger path fired AND the candidate muons have trigger-object matching |
 
-| Quantity | Branch |
-|----------|--------|
-| Event-level trigger decisions | `trigRes` (HLT results), `trigNames` (HLT path names) |
-| J/ψ trigger matching | `MatchJpsiTriggerNames` (which J/ψ trigger paths matched), `muIsJpsiTrigMatch` (per-muon trigger match) |
-| J/ψ filter matching | `muIsJpsiFilterMatch` |
+**Event-level trigger information** (one entry per HLT path in the event):
 
-The HLT step requires at least one of the configured J/ψ trigger paths to fire
-AND have trigger-object matching to the candidate muons.
+| Branch | Content |
+|--------|---------|
+| `TrigRes` | Accept bit (0/1) for each HLT path |
+| `TrigNames` | Name string for each HLT path |
+| `MatchJpsiTriggerNames` | Deduplicated list of which configured J/ψ trigger patterns fired |
+| `MatchUpsTriggerNames` | Same for Upsilon trigger patterns |
+| `L1TrigRes` | L1 technical trigger bits |
 
-Denominator: events with at least one valid `Jpsi_1` candidate (from the full
-chain ntuple, Run B).
+**Per-muon trigger matching** (one entry per muon in the event):
 
-### 2.9 four-muon vertexing — valid J/ψ J/ψ vertex
+| Branch | Content |
+|--------|---------|
+| `muIsJpsiTrigMatch` | Event-level boolean: 1 if any configured J/ψ trigger fired (same value for all muons) |
+| `muIsUpsTrigMatch` | Same for Upsilon triggers |
+| `muIsJpsiFilterMatch` | 1 if this muon's trigger objects match at least one configured J/ψ filter label |
+| `muIsUpsFilterMatch` | Same for Upsilon filters |
+| `muJpsiMatchedTriggerIndices` | Per-muon: list of trigger pattern indices (into `TriggersForJpsi`) that this muon matched |
+| `muJpsiMatchedFilterIndices` | Per-muon: list of filter label indices (into `FiltersForJpsi`) that this muon matched |
+| `muUpsMatchedTriggerIndices` | Per-muon: list of trigger pattern indices (into `TriggersForUpsilon`) that this muon matched |
+| `muUpsMatchedFilterIndices` | Per-muon: list of filter label indices (into `FiltersForUpsilon`) that this muon matched |
 
-| Quantity | Branch |
-|----------|--------|
-| DiOnia fit valid | `DiOnia_fitValid > 0` |
-| DiOnia fit passes prob cut | `DiOnia_fitPass > 0` (respects `DiOniaVtxProbCut`) |
-| Common reco-vertex check | `DiOnia_commonRecVtxPass > 0` |
+**Configuration reference** (from `X_Config_Tree`):
+`TriggersForJpsi`, `FiltersForJpsi`, `TriggersForUpsilon`, `FiltersForUpsilon` —
+the configured trigger path substrings and filter labels against which matching
+was performed.
 
-This step combines the two J/ψ candidates into a common vertex. It requires both
-`Jpsi_1` and `Jpsi_2` branches from the full chain ntuple (Run B).
+**Trigger matching workflow:**
 
-Denominator: events passing HLT with at least one valid dimuon pair for each of
-the two J/ψ slots.
+1. Check `MatchJpsiTriggerNames` is non-empty — at least one J/ψ trigger fired.
+2. For each `Jpsi_1` / `Jpsi_2` candidate, use `Jpsi_1_mu_1_Idx` /
+   `Jpsi_1_mu_2_Idx` to look up the muon indices.
+3. Check `muJpsiMatchedTriggerIndices[muIdx]` — non-empty means this muon's
+   trigger objects matched a configured J/ψ trigger path.
+4. A candidate passes trigger matching when at least one of its daughter muons
+   has a non-empty `muJpsiMatchedTriggerIndices`.
 
-### 2.10 triOnia — final three-meson vertex + event-level cuts
+The `muIsJpsiTrigMatch` flag alone is NOT sufficient for trigger-object
+matching — it only indicates the trigger fired for the event, not that a
+specific muon was responsible. Use `muJpsiMatchedTriggerIndices` for the
+per-muon association.
 
-| Quantity | Branch |
-|----------|--------|
-| Primary vertex fit valid | `Pri_fitValid > 0` |
-| Primary vertex fit passes prob cut | `Pri_fitPass > 0` (respects `PriVtxProbCut`) |
-| Common PV association | `Pri_assocPVPass > 0` |
-| Track PV compatibility | `Pri_trackPVPass > 0` |
-| Final mass check | Internal (`CheckFinalMass` flag) |
+### 2.9 four-muon vertexing — ε_{4μvtx}
 
-The code produces four parallel quality flags for the primary vertex. The
-default endpoint for corrected-yield studies is `Pri_assocPVPass / four_muon_vtx`
-as noted in `Efficiency_scheme.md`.
+| Role | Branch / logic |
+|------|----------------|
+| Denominator (passed HLT) | Events passing HLT trigger + trigger-object matching, with at least one valid dimuon pair for each of the two J/ψ slots |
+| Numerator (passes THIS step) | Denominator events where `DiOnia_fitValid > 0` AND `DiOnia_fitPass > 0` |
 
-Denominator: events passing four-muon vertexing, split by φ pT bins.
+This step combines two J/ψ candidates (`Jpsi_1` + `Jpsi_2`) into a common
+four-muon vertex (Run B). The baseline criterion is that the kinematic vertex
+fit converged and passes the vertex probability cut (`DiOniaVtxProbCut`).
+Alternative or additional criteria (e.g., `DiOnia_commonRecVtxPass`) may be
+applied depending on the analysis working point.
+
+### 2.10 triOnia — ε_{triOnia}
+
+| Role | Branch / logic |
+|------|----------------|
+| Denominator (passed four-muon vertexing) | Events passing four-muon vertexing (ε_{4μvtx} numerator), split by φ pT bins |
+| Numerator (passes THIS step) | Denominator events passing the chosen triOnia endpoint |
+
+The code produces four parallel quality flags for the three-meson primary vertex:
+
+| Flag | Meaning |
+|------|---------|
+| `Pri_fitValid > 0` | 3-body kinematic vertex fit converged |
+| `Pri_fitPass > 0` | Fit passes `PriVtxProbCut` |
+| `Pri_assocPVPass > 0` | Common PV association of daughter tracks |
+| `Pri_trackPVPass > 0` | Track-PV compatibility for daughter tracks |
+
+The default endpoint for corrected-yield studies is `Pri_assocPVPass` (per
+`Efficiency_scheme.md`). The denominator is four-muon-vertexing-passing events,
+split by φ pT bins. Alternative endpoints may use `Pri_fitPass` or
+`Pri_trackPVPass` depending on the analysis.
 
 ---
 
 ## 3. Configuration considerations
 
-### 3.1 Cuts that must be loose for denominator studies
-
-The following cuts are applied **before** single-object branches are filled and
-cannot be undone downstream. They must be set loosely for efficiency denominator
-evaluation:
-
-| Parameter | Tight default | Recommended loose |
-|-----------|--------------|-------------------|
-| `JpsiMassMin` / `JpsiMassMax` | 2.8 / 3.3 | 1.0 / 4.0 |
-| `PhiMassMin` / `PhiMassMax` | 0.97 / 1.07 | 0.8 / 1.2 |
-| `OniaDecayVtxProbCut` | 5e-4 | 0.0 (or keep) |
-| `JpsiDecayVtxProbCut` | 5e-4 | 0.0 (or keep) |
-| `PhiDecayVtxProbCut` | 5e-4 | 0.0 (or keep) |
-| `MuonSelection` | `pt > 2.5 && abs(eta) < 2.4` | Match your fiducial definition |
-| `TrackSelection` | `pt > 1.0 && abs(eta) < 2.5 && numberOfHits > 4` | Match your fiducial definition |
-
-These are hardcoded in `ConfFile_cfg.py` and not exposed via `VarParsing` (the
-`VarParsing` system only exposes the MC control switches, not the physics cut
-values). Maintain a separate loose-cut config file for efficiency studies, or
-override the values directly before `cmsRun`.
-
-### 3.2 Cuts you can tighten in post-processing
+### 3.1 Cuts you can tighten in post-processing
 
 | Parameter | Why post-processable |
 |-----------|---------------------|
@@ -234,15 +258,15 @@ override the values directly before `cmsRun`.
 | `MinTrackFromPV` | Recorded in `RecoKaonTrack_fromPV` and `SinglePhi_K*_fromPV`. |
 | Track `normalizedChi2`, `highPurity` | Recorded (indirectly) via `RecoKaonTrack_passTrackPV`. |
 
-### 3.3 MC control flags
+### 3.2 MC control flags
 
 | Flag | Effect on efficiency evaluation |
 |------|--------------------------------|
-| `keepAllSingleObjectCandsInMC=True` | **Required** — enables `SingleJpsi_*`, `SinglePhi_*`, `RecoKaonTrack_*` |
+| `keepAllSingleObjectCandsInMC=True` | **Required** — enables `SingleJpsi_*`, `SinglePhi_*` |
 | `skipCompositeCandBuildingWhenKeepingSingles=True` | Optional — skips `combineCandidates()` for a smaller, faster ntuple when only per-object steps are needed |
 | `requireAcceptedCandidatesForMonteCarloTree=False` | Recommended for efficiency — keeps every event even when no candidate passes |
 
-### 3.4 Vertex fit toggles
+### 3.3 Vertex fit toggles
 
 | Toggle | Default | Notes |
 |--------|---------|-------|
@@ -257,53 +281,63 @@ override the values directly before `cmsRun`.
 
 ### Step 1: Produce efficiency ntuples
 
-Run both Run A (singles-only) and Run B (full chain) with loose physics cuts on
-the full MC sample(s). Use `maxEvents=-1` to process all events.
+Run both Run A (singles-only) and Run B (full chain) on the full MC sample(s).
+Use `maxEvents=-1` to process all events.
 
 ### Step 2: Build per-object efficiency maps
 
+Each efficiency is conditional: ε_step = N(pass step) / N(pass previous step).
 For each J/ψ and φ kinematic bin `(pT, |y|)`:
 
-1. **Acceptance**: From `MC_GenPart_*`, count GEN J/ψ (or φ) in the bin.
-   Numerator: daughters in fiducial region. Denominator: all GEN J/ψ (or φ).
-   Output: `A_Jpsi(pT, |y|)`, `A_phi(pT, |y|)`.
+1. **Acceptance** — A_{J/ψ}, A_{φ}: From `MC_GenPart_*`.
+   - Denominator: all GEN J/ψ (or φ) in the kinematic bin.
+   - Numerator: denominator mesons where both GEN daughters are in the fiducial region.
 
-2. **muonRECO / kaonRECO**: From `SingleJpsi_*` / `SinglePhi_*` (Run A).
-   Numerator: candidates with both daughters `genMatchIdx >= 0`.
-   Denominator: candidates with both GEN daughters in fiducial acceptance.
-   Output: `eps_muReco(pT, |y|)`, `eps_kReco(pT, |y|)`.
+2. **muonRECO** — ε_{μReco|J/ψ}: From `SingleJpsi_*` (Run A).
+   - Denominator: `SingleJpsi` where both GEN daughters are in fiducial acceptance.
+   - Numerator: denominator candidates with both `mu*_genMatchIdx >= 0`.
 
-3. **muonID / kaonID**: From `SingleJpsi_*` + `mu*` / `SinglePhi_*` + `RecoKaonTrack_*`.
-   Numerator: RECO-passing candidates where both daughters pass ID.
-   Denominator: RECO-passing candidates.
-   Output: `eps_muID(pT, |y|)`, `eps_kID(pT, |y|)`.
+3. **kaonRECO** — ε_{KReco|φ}: From `SinglePhi_*` (Run A).
+   - Denominator: `SinglePhi` where both GEN daughters are in fiducial acceptance.
+   - Numerator: denominator candidates with both `K*_genMatchIdx >= 0`.
 
-4. **dimuon / dikaon**: From `SingleJpsi_*` / `SinglePhi_*`.
-   Numerator: candidates with `fitValid && fitPass`.
-   Denominator: ID-passing candidates.
-   Output: `eps_mumu(pT, |y|)`, `eps_KK(pT, |y|)`.
+4. **muonID** — ε_{μID|J/ψ}: From `SingleJpsi_*` + `mu*` (Run A).
+   - Denominator: `SingleJpsi` passing muonRECO (both muons GEN-matched).
+   - Numerator: denominator candidates where both daughter muons pass the chosen ID (baseline: `muIsPatSoftMuon`).
+
+5. **kaonID** — ε_{KID|φ}: From `SinglePhi_*` + `RecoKaonTrack_*` (Run A).
+   - Denominator: `SinglePhi` passing kaonRECO (both kaons GEN-matched).
+   - Numerator: denominator candidates where both daughter kaons pass the chosen track-quality ID.
+
+6. **dimuon** — ε_{μμ|J/ψ}: From `SingleJpsi_*` (Run A).
+   - Denominator: `SingleJpsi` passing muonID.
+   - Numerator: denominator candidates with `SingleJpsi_fitValid && SingleJpsi_fitPass`.
+
+7. **dikaon** — ε_{KK|φ}: From `SinglePhi_*` (Run A).
+   - Denominator: `SinglePhi` passing kaonID.
+   - Numerator: denominator candidates with `SinglePhi_fitValid && SinglePhi_fitPass`.
 
 ### Step 3: Build event-level efficiency maps
 
 From the full chain ntuple (Run B):
 
-1. **HLT**: Count events where trigger fired + trigger-object match exists.
-   Denominator: events with ≥1 valid dimuon candidate.
+1. **HLT** — ε_{HLT}:
+   - Denominator: events with ≥1 valid dimuon candidate.
+   - Numerator: denominator events where `MatchJpsiTriggerNames` is non-empty AND at least one daughter muon of the candidate has non-empty `muJpsiMatchedTriggerIndices`.
 
-2. **four-muon vertexing** (`eps_4muVtx`): From `DiOnia_*`.
-   Numerator: `DiOnia_fitValid && DiOnia_fitPass`.
-   Denominator: HLT-passing events.
+2. **four-muon vertexing** — ε_{4μvtx}: From `DiOnia_*` (Run B).
+   - Denominator: events passing HLT + trigger matching, with valid dimuon pairs in both J/ψ slots.
+   - Numerator: denominator events with `DiOnia_fitValid && DiOnia_fitPass`.
 
-3. **triOnia** (`eps_triOnia`): From `Pri_*`, split by φ pT bins.
-   Numerator: `Pri_assocPVPass` (or chosen endpoint).
-   Denominator: four-muon-vertexing-passing events.
+3. **triOnia** — ε_{triOnia}: From `Pri_*` (Run B), split by φ pT bins.
+   - Denominator: events passing four-muon vertexing.
+   - Numerator: denominator events passing the chosen endpoint (default: `Pri_assocPVPass`).
 
 ### Step 4: Apply correction
 
 The per-event total efficiency weight is the product of all per-object and
 event-level factors evaluated at the event's kinematics, times the factorized
-acceptance. See `Efficiency_scheme.md` Section "Definitions" for the product
-formula.
+acceptance. See `Efficiency_scheme.md` for the product formula.
 
 ---
 
@@ -317,10 +351,17 @@ between the per-object steps that the factorized approach misses.
 
 ### 5.2 RecoKaonTrack coverage
 
+The `RecoKaonTrack_*` block is always populated with the union of:
+- GEN-matched quality kaons (MC with `keepAllSingleObjectCandsInMC=True`),
+- φ-candidate daughter tracks from `KPairCand_Meson_` (always).
+
+The `RecoKaonTrack_usedInSinglePhi` flag distinguishes the two sources
+(1 = φ-candidate daughter, 0 = GEN-matched only).
+
 Verify that every φ-candidate daughter has a `RecoKaonTrack_*` entry:
-`SinglePhi_K*_RecoKaonTrackIdx >= 0` for all `SinglePhi` candidates. A `-1`
-sentinel indicates a kaon track missing from the RecoKaonTrack block (should
-not happen when `KeepAllSingleObjectCandsInMC=True`).
+`SinglePhi_K*_RecoKaonTrackIdx >= 0` for all `SinglePhi` candidates, and
+`Phi_K_*_RecoKaonTrackIdx >= 0` for all composite φ candidates. A `-1`
+sentinel should never occur.
 
 ### 5.3 Bin-edge sensitivity
 
@@ -329,6 +370,13 @@ the corrected yield is stable within MC statistical uncertainties.
 
 ### 5.4 GEN-RECO daughter matching consistency
 
-For `SinglePhi` candidates, compare the direct GEN-match info
-(`SinglePhi_K1_genMatchIdx`) with the RecoKaonTrack-level match
-(`RecoKaonTrack_genMatchIdx[SinglePhi_K1_RecoKaonTrackIdx]`). They must agree.
+For `SinglePhi` candidates, the inline GEN-match info (`SinglePhi_K1_genMatchIdx`,
+`SinglePhi_K2_genMatchIdx`) should agree with the RecoKaonTrack-level match
+(`RecoKaonTrack_genMatchIdx[SinglePhi_K1_RecoKaonTrackIdx]`,
+`RecoKaonTrack_genMatchIdx[SinglePhi_K2_RecoKaonTrackIdx]`). They are derived
+from the same `buildPhiKaonDiagnostics` call and must be identical.
+
+For composite φ candidates (`Phi_K_1_*` / `Phi_K_2_*`), the inline
+`Phi_K_1_genMatchIdx` / `Phi_K_2_genMatchIdx` can similarly be verified against
+`RecoKaonTrack_genMatchIdx[Phi_K_1_RecoKaonTrackIdx]` /
+`RecoKaonTrack_genMatchIdx[Phi_K_2_RecoKaonTrackIdx]`.

--- a/doc/Efficiency_Evaluation_Guideline.md
+++ b/doc/Efficiency_Evaluation_Guideline.md
@@ -121,19 +121,45 @@ point is analysis-configurable and can be tightened in post-processing.
 
 ### 2.5 kaonID — $\varepsilon_{K\mathrm{ID}|\phi}$
 
+Track-quality identification applied to the reconstructed (GEN-matched) kaon tracks.
+This is the third tier of the kaon efficiency chain, after fiducial acceptance and
+reconstruction.
+
+The kaon efficiency factorizes into three sequential tiers:
+
+| Tier | Step | Selection | Config / branches |
+|------|------|-----------|-------------------|
+| Fiducial acceptance | via $A_{\phi}$ (Section 2.1) | Phase-space only: $p_T$, $\eta$ cuts on GEN kaons | `TrackSelection` (`"pt > 1.0 && abs(eta) < 2.5"`) |
+| kaonRECO | $\varepsilon_{K\mathrm{Reco}}^{\phi}$ (Section 2.3) | Both kaons GEN-matched | `SinglePhi_K*_genMatchIdx >= 0` |
+| kaonID | $\varepsilon_{K\mathrm{ID}}^{\phi}$ (this section) | Track quality on reconstructed kaons | `TrackQuality` + `RequireRecoKaonTrackHighPurity` |
+
+Note: pT/eta cuts are part of fiducial acceptance, NOT kaonID. The `TrackSelection`
+string configures the phase-space denominator (see Section 3.1).
+
 | Role | Branch / logic |
 |------|----------------|
 | Denominator (passed kaonRECO) | `SinglePhi` candidates with both kaons GEN-matched (kaonRECO numerator) |
-| Numerator (passes THIS step) | Denominator `SinglePhi` where both daughter kaons pass the chosen track-quality ID working point |
+| Numerator (passes THIS step) | Denominator `SinglePhi` where both daughter kaons pass track-quality ID |
 
 Use `SinglePhi_K1_RecoKaonTrackIdx` / `SinglePhi_K2_RecoKaonTrackIdx` to look up
 the `RecoKaonTrack_*` block (always populated from φ-candidate daughters).
 
-The baseline kaon ID is the `TrackSelection` string cut applied at the input
-level (e.g., `pt > 1.0 && abs(eta) < 2.5 && numberOfHits > 4`). This is
-analysis-configurable. PV-compatibility flags (`RecoKaonTrack_passDzPV`,
-`RecoKaonTrack_passDxyPV`, `RecoKaonTrack_passTrackPV`, `RecoKaonTrack_fromPV`)
-are reserved for the dikaon and triOnia vertexing steps below.
+The baseline track-quality criteria are defined by two config parameters (stored
+in `X_Config_Tree`):
+
+| Parameter | Default | Branch equivalents |
+|-----------|---------|-------------------|
+| `TrackQuality` | `"normalizedChi2 < 8 && numberOfValidHits > 4"` | `RecoKaonTrack_normalizedChi2`, `RecoKaonTrack_numberOfHits` |
+| `RequireRecoKaonTrackHighPurity` | `True` | `RecoKaonTrack_isHighPurity == 1` |
+
+Both criteria must be satisfied for each daughter kaon to count as passing kaonID.
+The quality cuts are fully configurable at production time and can be varied in
+offline analysis without re-ntuplizing, since the raw quality values are stored
+per-track in the `RecoKaonTrack_*` block.
+
+PV-compatibility flags (`RecoKaonTrack_passDzPV`, `RecoKaonTrack_passDxyPV`,
+`RecoKaonTrack_passTrackPV`, `RecoKaonTrack_fromPV`) are reserved for the dikaon
+and triOnia vertexing steps below.
 
 ### 2.6 dimuon — $\varepsilon_{\mu\mu|J/\psi}$
 
@@ -255,8 +281,8 @@ split by φ pT bins. Alternative endpoints may use `Pri_fitPass` or
 |-----------|---------------------|
 | `JpsiCandPtMin`, `JpsiCandEtaMax` | These are applied in `pairMuons()` as pre-cuts on the composite candidate. The `SingleJpsi_pt` branch records the value; you can apply any pT cut in analysis. |
 | `PhiCandPtMin`, `PhiCandEtaMax` | Same reasoning — `SinglePhi_pt` records the value. |
+| Track quality (`normalizedChi2`, `numberOfValidHits`, `isHighPurity`) | Directly recorded in `RecoKaonTrack_normalizedChi2`, `RecoKaonTrack_numberOfHits`, `RecoKaonTrack_isHighPurity`. Configurable via `TrackQuality` string and `RequireRecoKaonTrackHighPurity` flag. |
 | `MinTrackFromPV` | Recorded in `RecoKaonTrack_fromPV` and `SinglePhi_K*_fromPV`. |
-| Track `normalizedChi2`, `highPurity` | Recorded (indirectly) via `RecoKaonTrack_passTrackPV`. |
 
 ### 3.2 MC control flags
 
@@ -307,7 +333,11 @@ For each J/ψ and φ kinematic bin `(pT, |y|)`:
 
 5. **kaonID** — $\varepsilon_{K\mathrm{ID}|\phi}$: From `SinglePhi_*` + `RecoKaonTrack_*` (Run A).
    - Denominator: `SinglePhi` passing kaonRECO (both kaons GEN-matched).
-   - Numerator: denominator candidates where both daughter kaons pass the chosen track-quality ID.
+   - Numerator: denominator candidates where both daughter kaons satisfy the track-quality criteria:
+     - `RecoKaonTrack_normalizedChi2[idx] < 8 && RecoKaonTrack_numberOfHits[idx] > 4`
+     - `RecoKaonTrack_isHighPurity[idx] == 1`
+   - The exact criteria are documented in `X_Config_Tree::TrackQuality` and `X_Config_Tree::RequireRecoKaonTrackHighPurity`.
+   - Quality cuts can be varied offline without re-ntuplizing since the raw values are stored.
 
 6. **dimuon** — $\varepsilon_{\mu\mu|J/\psi}$: From `SingleJpsi_*` (Run A).
    - Denominator: `SingleJpsi` passing muonID.
@@ -352,7 +382,7 @@ between the per-object steps that the factorized approach misses.
 ### 5.2 RecoKaonTrack coverage
 
 The `RecoKaonTrack_*` block is always populated with the union of:
-- GEN-matched quality kaons (MC with `keepAllSingleObjectCandsInMC=True`),
+- GEN-matched fiducial kaons — all kaons passing phase-space `TrackSelection` (MC with `keepAllSingleObjectCandsInMC=True`), independent of track quality,
 - φ-candidate daughter tracks from `KPairCand_Meson_` (always).
 
 The `RecoKaonTrack_usedInSinglePhi` flag distinguishes the two sources

--- a/doc/Efficiency_scheme.md
+++ b/doc/Efficiency_scheme.md
@@ -6,12 +6,20 @@
 | muonRECOinJpsi                              | $\epsilon_{\mu\mathrm{Reco}}^{J/\psi}$                  | per $J/\psi$             | $(p_T^{J/\psi}, y^{J/\psi})$                             | both daughter muons reconstructed and matched                |
 | kaonRECOinPhi                               | $\epsilon_{K\mathrm{Reco}}^{\phi}$                      | per $\phi$               | $(p_T^{\phi}, y^{\phi})$                                 | both kaons reconstructed and matched                         |
 | muonID                                      | $\epsilon_{\mu\mathrm{ID}}^{J/\psi}$                    | per $J/\psi$             | $(p_T^{J/\psi}, y^{J/\psi})$                             | both matched muons pass ID                                   |
-| kaonID                                      | $\epsilon_{K\mathrm{ID}}^{\phi}$                        | per $\phi$               | $(p_T^{\phi}, y^{\phi})$                                 | both matched kaons pass track/kaon selection                 |
+| kaonID                                      | $\epsilon_{K\mathrm{ID}}^{\phi}$                        | per $\phi$               | $(p_T^{\phi}, y^{\phi})$                                 | both matched kaons pass track quality selection (normalizedChi2, numberOfValidHits, isHighPurity) |
 | dimuon                                      | $\epsilon_{\mu\mu}^{J/\psi}$                            | per $J/\psi$             | $(p_T^{J/\psi}, y^{J/\psi})$                             | valid dimuon candidate                                       |
 | dikaon                                      | $\epsilon_{KK}^{\phi}$                                  | per $\phi$               | $(p_T^{\phi}, y^{\phi})$                                 | valid $K^+K^-$ candidate                                     |
 | HLT                                         | $\epsilon_{\mathrm{HLT}}$                               | event                    | nominally event-level                                    | trigger OR and trigger-object matching                       |
 | fourMuonVertexing                           | $\epsilon_{4\mu\mathrm{vtx}}$                           | per $J/\psi J/\psi$ pair | pair-level axes                                          | valid four-muon vertex                                       |
 | triOniaVertexingAndOtherEventLevelSelection | $\epsilon_{\mathrm{triOnia}}$                           | event                    | $(p_T^{J/\psi_1},p_T^{J/\psi_2})$, split by $p_T^{\phi}$ | three-meson vertex and remaining event-level cuts            |
+
+The kaon efficiency chain factorizes into three tiers:
+
+| Tier | Step | Selection | Config / branches |
+|------|------|-----------|-------------------|
+| Fiducial acceptance | via $A_{\phi}$ | $p_T$, $\eta$ phase-space only | `TrackSelection` (`pt > ... && abs(eta) < ...`) |
+| Reconstruction | $\epsilon_{K\mathrm{Reco}}^{\phi}$ | GEN-matched kaons (daughter-level) | `RecoGenKaonMatchChi2Max`, `SinglePhi_K*_genMatchIdx >= 0` |
+| KaonID | $\epsilon_{K\mathrm{ID}}^{\phi}$ | Track quality on reconstructed kaons | `TrackQuality` (`normalizedChi2`, `numberOfValidHits`) + `RequireRecoKaonTrackHighPurity` |
 
 ### Current implementation notes
 

--- a/doc/Efficiency_scheme.md
+++ b/doc/Efficiency_scheme.md
@@ -1,0 +1,319 @@
+### Efficiency and acceptance scheme
+
+| Step                                        | Symbol                                                  | Level                    | Map axes                                                 | Short definition                                             |
+| ------------------------------------------- | ------------------------------------------------------- | ------------------------ | -------------------------------------------------------- | ------------------------------------------------------------ |
+| Acceptance                                  | $A_{J/\psi}(\vec{x}_{J_i})$, $A_{\phi}(\vec{x}_{\phi})$ | per $J/\psi$ or $\phi$   | $(p_T^{\mathrm{meson}}, |y^{\mathrm{meson}}|)$           | decay daughters in fiducial region given meson in acceptance |
+| muonRECOinJpsi                              | $\epsilon_{\mu\mathrm{Reco}}^{J/\psi}$                  | per $J/\psi$             | $(p_T^{J/\psi}, y^{J/\psi})$                             | both daughter muons reconstructed and matched                |
+| kaonRECOinPhi                               | $\epsilon_{K\mathrm{Reco}}^{\phi}$                      | per $\phi$               | $(p_T^{\phi}, y^{\phi})$                                 | both kaons reconstructed and matched                         |
+| muonID                                      | $\epsilon_{\mu\mathrm{ID}}^{J/\psi}$                    | per $J/\psi$             | $(p_T^{J/\psi}, y^{J/\psi})$                             | both matched muons pass ID                                   |
+| kaonID                                      | $\epsilon_{K\mathrm{ID}}^{\phi}$                        | per $\phi$               | $(p_T^{\phi}, y^{\phi})$                                 | both matched kaons pass track/kaon selection                 |
+| dimuon                                      | $\epsilon_{\mu\mu}^{J/\psi}$                            | per $J/\psi$             | $(p_T^{J/\psi}, y^{J/\psi})$                             | valid dimuon candidate                                       |
+| dikaon                                      | $\epsilon_{KK}^{\phi}$                                  | per $\phi$               | $(p_T^{\phi}, y^{\phi})$                                 | valid $K^+K^-$ candidate                                     |
+| HLT                                         | $\epsilon_{\mathrm{HLT}}$                               | event                    | nominally event-level                                    | trigger OR and trigger-object matching                       |
+| fourMuonVertexing                           | $\epsilon_{4\mu\mathrm{vtx}}$                           | per $J/\psi J/\psi$ pair | pair-level axes                                          | valid four-muon vertex                                       |
+| triOniaVertexingAndOtherEventLevelSelection | $\epsilon_{\mathrm{triOnia}}$                           | event                    | $(p_T^{J/\psi_1},p_T^{J/\psi_2})$, split by $p_T^{\phi}$ | three-meson vertex and remaining event-level cuts            |
+
+### Current implementation notes
+
+The parquet efficiency workflow stores object-level reconstruction and ID steps
+as conditional chains, then switches to event-level flags. The nominal event
+chain is:
+
+```text
+s_cand -> hlt_event -> four_muon_vtx
+```
+
+The primary-vertex diagnostics are parallel branches with denominator
+`four_muon_vtx`, not a single cumulative final step:
+
+```text
+Pri_fitValid
+Pri_fitPass
+Pri_assocPVPass
+Pri_trackPVPass
+```
+
+For corrected-yield studies the default correction is factorized rather than a
+single cumulative `correlated_3d` lookup. It multiplies per-object acceptance and
+conditional efficiency maps in `(pT, |y|)` by event-level maps for HLT,
+four-muon vertexing, and the final tri-onia/PV endpoint. The default endpoint is
+`Pri_assocPVPass / four_muon_vtx`.
+
+Factorized map lookup uses a tiered fallback:
+
+```text
+fine bin -> coarse bin -> inclusive bin
+```
+
+The nominal central value uses observed bin efficiencies after fallback
+selection. Jeffreys symmetric binomial uncertainties are stored for each bin and
+used for MC-stat diagnostics. The default thresholds are `N_min_fine = 30` and
+`N_min_coarse = 50`.
+
+The stacked J/psi derived plots are diagnostics for the two J/psi objects
+combined into one per-object map. Their parquet products use direct
+`(pT, |y|)` binning (`y_axis == "abs_y"`):
+
+```text
+stacked_jpsi_acceptance_maps.parquet: fiducial acceptance
+stacked_jpsi_efficiency_maps.parquet: muonRECO, muonID, dimuon
+```
+
+When only these plots are needed, use `build_derived_efficiency.py
+--plot-scope stacked-jpsi` to skip cumulative, conditional, pair-level, and
+systematics plots.
+
+The correction workflow is:
+
+```bash
+python3 rebuild_efficiency_maps.py \
+  --input-dir <merged_efficiency_dir> \
+  --output-dir <fresh_rebuilt_dir> \
+  --samples JJP_DPS1 JJP_DPS2_CS JJP_DPS2_G JJP_SPS_CS JJP_SPS_G
+
+python3 build_derived_efficiency.py --input-dir <fresh_rebuilt_dir>
+
+python3 -m efficiency_workflow.build_factorized_maps \
+  --input-dir <fresh_rebuilt_dir> \
+  --samples JJP_DPS1 JJP_DPS2_CS JJP_DPS2_G JJP_SPS_CS JJP_SPS_G
+
+python3 compute_efficiency_corrected_yield.py \
+  --data-input <jjp_data_selected.root> \
+  --efficiency-dir <fresh_rebuilt_dir> \
+  --plot-dir <yield_plot_dir> \
+  --corrected-root <jjp_data_effcorr_selected.root> \
+  -o <yield_summary.json>
+
+python3 fit_splot.py \
+  --channel JJP --dataset data \
+  -i <jjp_data_effcorr_selected.root> \
+  -o <jjp_data_effcorr_splot.root> \
+  --effcorr-weight-branch effcorr_weight
+
+python3 plot_weighted_distributions.py \
+  --channel JJP --dataset data \
+  -i <jjp_data_effcorr_splot.root> \
+  -o <effcorr_splot_dynamics> \
+  -w signal_effcorr_sw
+```
+
+### Definitions
+
+Let
+
+$$
+J_i \equiv J/\psi_i,\qquad i=1,2,
+$$
+
+and
+
+$$
+\vec{x}*{J_i}=(p_T^{J_i}, |y^{J_i}|),\qquad
+\vec{x}*{\phi}=(p_T^\phi, |y^\phi|).
+$$
+
+The general acceptance is defined as the fraction of generated events whose decay products are within the fiducial region, which is defined as:
+
+$$
+  A_{\mathrm{tot}} = \frac{
+    N_{\mathrm{gen}}^{\mathrm{fid}}
+  }{
+    N_{\mathrm{gen}}(J_1, J_2, \phi\in\Omega_{\mathrm{meson}})
+  }
+$$
+
+Equivalently, one write:
+
+$$
+A_{\mathrm{tot}} = \frac{
+    N_{\mathrm{gen}}
+      \left( 
+        \mu^\pm\in\Omega_\mu,
+        K^\pm\in\Omega_K
+        \middle | 
+        J_1, J_2, \phi\in\Omega_{\mathrm{meson}}
+      \right)
+  }{
+    N_{\mathrm{gen}}
+      \left(
+        J_1, J_2, \phi\in\Omega_{\mathrm{meson}}
+      \right)
+  }
+$$
+
+A cross check is to factorize the acceptance by the $J/\psi$ and $\phi$ meson level:
+
+$$
+A_{J/\psi}(\vec{x}_{J_i})
+=
+\frac{
+N_{\mathrm{gen}}(\mu_1\in\Omega_\mu, \mu_2\in\Omega_\mu | J_i\in\Omega_{\mathrm{meson}})
+}{
+N_{\mathrm{gen}}(J_i\in\Omega_{\mathrm{meson}})
+}
+$$
+
+$$
+A_{\phi}(\vec{x}_{\phi})
+=
+\frac{
+N_{\mathrm{gen}}(K_1\in\Omega_K, K_2\in\Omega_K | \phi\in\Omega_{\mathrm{meson}})
+}{
+N_{\mathrm{gen}}(\phi\in\Omega_{\mathrm{meson}})
+}
+$$
+
+And we approximate with:
+
+$$
+A_{\mathrm{tot}} (\vec{x}_{J_1}, \vec{x}_{J_2}, \vec{x}_{\phi}) \approx A_{J/\psi}(\vec{x}_{J_1}) A_{J/\psi}(\vec{x}_{J_2}) A_{\phi}(\vec{x}_{\phi}).
+$$
+
+This approximation is exact only if the acceptance of each meson is independent of the kinematics of the other mesons. Since unpolarized nature of the $J/\psi$'s are assumed, one may expect that the acceptance of each $J/\psi$ is not strongly dependent on the kinematics of the other $J/\psi$ or the $\phi$.
+
+We further define the efficiency of each step as the fraction of events passing the step selection among the events passing the previous step selection, with the same kinematic binning as the acceptance.
+
+For each $J/\psi$,
+
+$$
+\epsilon_{\mu\mathrm{Reco}|J_i}(\vec{x}_{J_i})
+=
+
+\frac{
+N(S_{\mathrm{fid}}\cap\mu_1^{\mathrm{reco}}\cap\mu_2^{\mathrm{reco}})
+}{
+N(S_{\mathrm{fid}})
+},
+$$
+
+$$
+\epsilon_{\mu\mathrm{ID}|J_i}(\vec{x}_{J_i})
+=
+
+\frac{
+N(S_{\mu\mathrm{Reco}}\cap\mu_1^{\mathrm{ID}}\cap\mu_2^{\mathrm{ID}})
+}{
+N(S_{\mu\mathrm{Reco}})
+},
+$$
+
+$$
+\epsilon_{\mu\mu|J_i}(\vec{x}_{J_i})
+=
+
+\frac{
+N(S_{\mu\mathrm{ID}}\cap J_i^{\mathrm{reco}})
+}{
+N(S_{\mu\mathrm{ID}})
+}.
+$$
+
+For the (\phi),
+
+$$
+\epsilon_{K\mathrm{Reco}|\phi}(\vec{x}_{\phi})
+=
+
+\frac{
+N(S_{\mathrm{fid}}\cap K_1^{\mathrm{reco}}\cap K_2^{\mathrm{reco}})
+}{
+N(S_{\mathrm{fid}})
+},
+$$
+
+$$
+\epsilon_{K\mathrm{ID}|\phi}(\vec{x}_{\phi})
+=
+
+\frac{
+N(S_{K\mathrm{Reco}}\cap K_1^{\mathrm{ID}}\cap K_2^{\mathrm{ID}})
+}{
+N(S_{K\mathrm{Reco}})
+},
+$$
+
+$$
+\epsilon_{KK|\phi}(\vec{x}_{\phi})
+=
+
+\frac{
+N(S_{K\mathrm{ID}}\cap \phi^{\mathrm{reco}})
+}{
+N(S_{K\mathrm{ID}})
+}.
+$$
+
+The trigger efficiency is
+
+$$
+\epsilon_{\mathrm{HLT}}
+=
+
+\frac{
+N(S_{\mathrm{cand}}\cap \mathrm{HLT})
+}{
+N(S_{\mathrm{cand}})
+}.
+$$
+
+The four-muon vertexing efficiency is defined at the (J/\psi J/\psi)-pair level:
+
+$$
+\epsilon_{4\mu\mathrm{vtx}}(\vec{x}_{JJ})
+=
+
+\frac{
+N(S_{\mathrm{HLT}}\cap V_{4\mu})
+}{
+N(S_{\mathrm{HLT}})
+}.
+$$
+
+The final event-level efficiency is
+
+$$
+\epsilon_{\mathrm{triOnia}}^{(k)}(p_T^{J_1},p_T^{J_2})
+=
+
+\frac{
+N(S_{4\mu\mathrm{vtx}}\cap V_{J/\psi J/\psi\phi}\cap S_{\mathrm{other}};,p_T^\phi\in I_k)
+}{
+N(S_{4\mu\mathrm{vtx}};,p_T^\phi\in I_k)
+}.
+$$
+
+Here (I_k) is the (k)-th (\phi)-(p_T) interval used for plotting.
+
+The total fiducial efficiency is
+
+$$
+\begin{aligned}
+\epsilon_{\mathrm{fid}}
+={}&
+\prod_{i=1}^{2}
+\epsilon_{\mu\mathrm{Reco}|J_i}
+\epsilon_{\mu\mathrm{ID}|J_i}
+\epsilon_{\mu\mu|J_i}
+\
+&\times
+\epsilon_{K\mathrm{Reco}|\phi}
+\epsilon_{K\mathrm{ID}|\phi}
+\epsilon_{KK|\phi}
+\
+&\times
+\epsilon_{\mathrm{HLT}}
+\epsilon_{4\mu\mathrm{vtx}}
+\epsilon_{\mathrm{triOnia}} .
+\end{aligned}
+$$
+
+And the full correction factor is
+
+$$
+A\epsilon
+=
+
+A_{\mathrm{tot}}\epsilon_{\mathrm{fid}}.
+$$
+
+### 

--- a/doc/RecoKaonTrack_fix_plan.md
+++ b/doc/RecoKaonTrack_fix_plan.md
@@ -1,0 +1,89 @@
+# Fix: Apply track quality filter to GEN-matched tracks in RecoKaonTrack
+
+## Problem
+
+The current Pass A in `fillRecoKaonTrackBlockForMC()` (line 1863-1864) accepts every GEN-matched track unconditionally:
+
+```cpp
+if (diagnostics.genMatchIdx >= 0) {
+    selectedNonMuonTrackIdx.insert(nonMuonIdx);
+}
+```
+
+This stores 82 GEN-only tracks in 50 events, many of which are soft (pt down to 0.28 GeV) or forward (|η| up to 2.87) — tracks that would never enter a phi candidate because they fail the quality cuts in `pairTracks()`. For acceptance evaluation only GEN-level is needed (no RECO block). For efficiency, only tracks within fiducial + quality acceptance matter.
+
+## Fix (applied in v1.8)
+
+The solution factorizes the kaon selection into three tiers:
+
+1. **`TrackSelection`** (phase-space only): `"pt > 1.0 && abs(eta) < 2.5"` — defines the fiducial denominator for the RecoKaonTrack block.
+2. **`TrackQuality`** + **`RequireRecoKaonTrackHighPurity`**: new config parameters defining the kaonID quality criteria, applied in `pairTracks()` to gate φ candidate building and stored in the config TTree for offline numerator computation.
+3. **Raw quality values** (`RecoKaonTrack_normalizedChi2`, `_numberOfHits`, `_isHighPurity`): stored per-track in the RecoKaonTrack block (added in v1.7), enabling offline variation of quality cuts without re-ntuplizing.
+
+The hardcoded quality cuts in `fillRecoKaonTrackBlock()` Step A are removed
+entirely. Step A now requires only phase-space `trackSelector_` + `genMatchIdx >= 0`.
+The hardcoded cuts in `pairTracks()` are replaced with the configurable
+`trackQualitySelector_(*bestTrack)` and `requireRecoKaonTrackHighPurity_` flag.
+
+## Code changes (v1.8, applied)
+
+### `fillRecoKaonTrackBlock()` Step A (simplified)
+
+**File:** `src/MultiLepPAT.cc`, the Pass A loop.
+
+The entry criteria are simplified to phase-space + GEN-match only (no quality cuts):
+
+```cpp
+    for (unsigned int nonMuonIdx = 0; nonMuonIdx < nonMuonTrack_.size(); ++nonMuonIdx) {
+        const auto& cand = *nonMuonTrack_[nonMuonIdx];
+        const auto diagnostics = buildPhiKaonDiagnostics(cand, thePrimaryV_, genParticles);
+        diagnosticsCache[nonMuonIdx] = diagnostics;
+
+        const bool passesTrackSel = trackSelector_(cand);
+        if (diagnostics.genMatchIdx >= 0 && passesTrackSel) {
+            selectedNonMuonTrackIdx.insert(nonMuonIdx);
+        }
+    }
+```
+
+### `pairTracks()` quality cuts (configurable)
+
+Hardcoded `normalizedChi2 <= 8.0` and `quality(reco::Track::highPurity)` replaced with:
+
+```cpp
+if (!trackQualitySelector_(*cand.bestTrack()) ||
+    (requireRecoKaonTrackHighPurity_ &&
+     !cand.bestTrack()->quality(reco::Track::highPurity))) continue;
+```
+
+### New config parameters
+
+Added to constructor, config TTree, and all Python config files:
+- `TrackQuality` (string, default `"normalizedChi2 < 8 && numberOfValidHits > 4"`)
+- `RequireRecoKaonTrackHighPurity` (bool, default `True`)
+
+## Three-tier selection summary
+
+| Tier | Where applied | Cuts | Config |
+|------|--------------|------|--------|
+| Fiducial acceptance | `fillRecoKaonTrackBlock()` Step A | `trackSelector_` (p_T, η phase-space only) | `TrackSelection` |
+| Reconstruction | GEN-matching in `buildPhiKaonDiagnostics()` | `genMatchIdx >= 0` (GEN kaon from φ mother) | `RecoGenKaonMatchChi2Max` |
+| KaonID | `pairTracks()` quality gate + offline | `trackQualitySelector_` + `requireRecoKaonTrackHighPurity_` | `TrackQuality` + `RequireRecoKaonTrackHighPurity` |
+
+## Expected impact
+
+Compared to the pre-v1.8 architecture (where Step A applied hardcoded quality cuts):
+
+- **RecoKaonTrack block expands**: Now includes all fiducial GEN-matched kaons,
+  not just those passing quality cuts. This enables proper denominator definition
+  for kaonID efficiency.
+- **φ candidates unchanged**: With default quality settings, `pairTracks()`
+  applies the same cuts as before, so φ candidate yields are identical.
+- **Offline flexibility**: Raw quality values stored per-track allow kaonID
+  working point to be varied without re-ntuplizing.
+
+## Verification
+
+1. **Build**: `scram b -j 4`
+2. **Run on MC**: `cmsRun test/ConfFile_cfg.py AnalysisMode=JpsiJpsiPhi inputFiles=file:test_muonPackedMatch_mcRun2022_numEvent2000.root outputFile=test_recoKaonTrack.root`
+3. **Check output**: GEN-only count should drop significantly; phi-only count unchanged; "neither" category stays zero.

--- a/doc/Validation_Test_Plan.md
+++ b/doc/Validation_Test_Plan.md
@@ -366,10 +366,10 @@ for i in range(tree.GetEntries()):
         summary["bad_single_jpsi_mu_indices"] += int(idx < 0 or idx >= tree.nMu)
     for idx in tree.SingleJpsi_mu2_Idx:
         summary["bad_single_jpsi_mu_indices"] += int(idx < 0 or idx >= tree.nMu)
-    for idx in tree.SinglePhi_K1_nonMuonTrackIdx:
-        summary["negative_single_phi_track_indices"] += int(idx < 0)
-    for idx in tree.SinglePhi_K2_nonMuonTrackIdx:
-        summary["negative_single_phi_track_indices"] += int(idx < 0)
+    for idx in tree.SinglePhi_K1_RecoKaonTrackIdx:
+        summary["negative_single_phi_reco_kaon_track_indices"] += int(idx < 0)
+    for idx in tree.SinglePhi_K2_RecoKaonTrackIdx:
+        summary["negative_single_phi_reco_kaon_track_indices"] += int(idx < 0)
 
     summary["single_jpsi_mu_gen_matches"] += sum(
         1 for x in tree.SingleJpsi_mu1_genMatchIdx if x >= 0)
@@ -771,7 +771,7 @@ Additional checks:
 | Max `nSingleJpsiCand` | 2 | 2 |
 | Max `nSinglePhiCand` | 8 | 8 |
 | Bad `SingleJpsi_mu*_Idx` values | 0 | 0 |
-| Negative `SinglePhi_K*_nonMuonTrackIdx` values | 0 | 0 |
+| Negative `SinglePhi_K*_RecoKaonTrackIdx` values | 0 | 0 |
 | Matched single-J/ψ daughter muons | 18 | 18 |
 | Matched single-φ daughter kaons | 4 | 4 |
 | Sentinel `Pri_mass` events | 0 | 0 |
@@ -803,7 +803,7 @@ Additional checks:
 | Max `nSinglePhiCand` | 10 | 10 |
 | Max `nSingleUpsCand` | 0 | 0 |
 | Bad `SingleJpsi_mu*_Idx` values | 0 | 0 |
-| Negative `SinglePhi_K*_nonMuonTrackIdx` values | 0 | 0 |
+| Negative `SinglePhi_K*_RecoKaonTrackIdx` values | 0 | 0 |
 | Matched single-J/psi daughter muons | 32 | 32 |
 | Matched single-phi daughter kaons | 6 | 6 |
 | Sentinel `Pri_mass` events | 0 | 0 |

--- a/doc/Validation_Test_Plan.md
+++ b/doc/Validation_Test_Plan.md
@@ -26,11 +26,11 @@
 | **3** | Per-resonance candidate pT/eta pre-cuts (6 new config params) | `.h`, `.cc`, both `.py` configs |
 | **4** | Sentinel values (`−999999`) for failed 3-body vertex fits | `.h` (decl), `.cc` (`storeSentinelPri()`, `combineCandidates()`) |
 
-### 0.3 Naming Clarification (planned, not yet applied)
+### 0.3 Naming Clarification (applied)
 
-The variables `jpsiPairPtMin_`, `upsPairPtMin_`, `phiPairPtMin_` (and their `EtaMax` counterparts) are **ambiguous**: they could be misread as "the pT of a pair of J/ψ's" rather than "the pT of the dimuon/dikaon pair forming a single J/ψ/Υ/φ candidate."
+The variables `jpsiPairPtMin_`, `upsPairPtMin_`, `phiPairPtMin_` (and their `EtaMax` counterparts) were **ambiguous**: they could be misread as "the pT of a pair of J/ψ's" rather than "the pT of the dimuon/dikaon pair forming a single J/ψ/Υ/φ candidate."
 
-**Planned rename** (6 members + 6 config keys + 6 config values in 2 `.py` files):
+**Applied rename** (6 members + 6 config keys + 6 config values in 2 `.py` files):
 
 | Old C++ member | New C++ member | Old config key | New config key |
 |----------------|---------------|----------------|----------------|
@@ -42,8 +42,6 @@ The variables `jpsiPairPtMin_`, `upsPairPtMin_`, `phiPairPtMin_` (and their `Eta
 | `phiPairEtaMax_` | `phiCandEtaMax_` | `PhiPairEtaMax` | `PhiCandEtaMax` |
 
 The word "Cand" (candidate) makes it clear that this is the pT of the **single composite candidate** (e.g., the dimuon system forming one J/ψ), not a pair of J/ψ candidates.
-
-**Files to modify**: `MultiLepPAT.h`, `MultiLepPAT.cc`, `ConfFile_cfg.py`, `runMultiLepPAT_MCRun3_miniAOD_Run2022.py`, and the corresponding header comment block.
 
 ---
 
@@ -586,9 +584,12 @@ f.Close()
 | `Ups_*` | ❌ Empty | Not used in this mode |
 | `Pri_*` | ✅ Yes | 3-body combined fit (or sentinel −999999) |
 | `Phi_K_1_*`, `Phi_K_2_*` | ✅ Yes | Kaon tracks |
+| `Phi_K_*_RecoKaonTrackIdx` | ✅ / ❌ | MC with singles: populated; otherwise `-1` |
 | `MatchJpsiTriggerNames` | ✅ Yes | Matched J/ψ trigger paths |
 | `MatchUpsTriggerNames` | ✅ Yes (likely empty) | No Υ triggers expected in JJPhi MC |
-| `MC_GenPart_*` | ✅ Yes | Gen-level info (DoMonteCarloTree=True) |
+| `MC_GenPart_*` | ✅ Yes (MC only) | Gen-level info |
+| `SingleJpsi_*`, `SingleUps_*`, `SinglePhi_*` | ✅ / ❌ | MC with `KeepAllSingleObjectCandsInMC=True` only |
+| `RecoKaonTrack_*` | ✅ / ❌ | MC with `KeepAllSingleObjectCandsInMC=True` only |
 
 ### 5.2 JpsiJpsiUps Mode
 
@@ -600,7 +601,10 @@ f.Close()
 | `Ups_*` | ✅ Yes | Υ from `muPairCand_Onia2_` |
 | `Pri_*` | ✅ Yes | 3-body combined fit (or sentinel) |
 | `Phi_K_*` | ❌ Empty | No kaons |
+| `Phi_K_*_RecoKaonTrackIdx` | ❌ Empty | No φ candidates |
 | `MatchUpsTriggerNames` | ✅ Yes (may be empty) | Depends on HLT menu in MC |
+| `SingleJpsi_*`, `SingleUps_*` | ✅ / ❌ | MC with `KeepAllSingleObjectCandsInMC=True` only |
+| `SinglePhi_*`, `RecoKaonTrack_*` | ❌ Empty | No kaons |
 
 ### 5.3 JpsiUpsPhi Mode
 
@@ -612,8 +616,11 @@ f.Close()
 | `Jpsi_2_*` | ❌ Empty | Not used in this mode |
 | `Pri_*` | ✅ Yes | 3-body fit (or sentinel) |
 | `Phi_K_*` | ✅ Yes | Kaon tracks for φ |
+| `Phi_K_*_RecoKaonTrackIdx` | ✅ / ❌ | MC with singles: populated; otherwise `-1` |
 | `MatchJpsiTriggerNames` | ✅ Yes | J/ψ trigger matches |
 | `MatchUpsTriggerNames` | ✅ Yes | Υ trigger matches |
+| `SingleJpsi_*`, `SingleUps_*`, `SinglePhi_*` | ✅ / ❌ | MC with `KeepAllSingleObjectCandsInMC=True` only |
+| `RecoKaonTrack_*` | ✅ / ❌ | MC with `KeepAllSingleObjectCandsInMC=True` only |
 
 ---
 
@@ -634,7 +641,7 @@ f.Close()
 - Mass windows too narrow (check `JpsiMassMin/Max`, `UpsMassMin/Max`)
 - `OniaDecayVtxProbCut` too tight
 - `MinMuonCount` too high for the MC sample
-- Per-resonance pT/eta cuts filtering everything (defaults are permissive: pT > 0, |η| < 999)
+- Per-resonance pT/eta cuts filtering everything (tight defaults: JpsiCandPtMin=4.0, PhiCandPtMin=2.0; set to 0.0 and 999.0 to loosen)
 
 ### 6.4 Sentinel Values
 **Symptom**: `Pri_mass` contains `−999999`.

--- a/doc/Validation_Test_Plan.md
+++ b/doc/Validation_Test_Plan.md
@@ -1,0 +1,864 @@
+# MultiLepPAT Refactored Analyzer — Validation Test Plan
+
+> **Date**: 2026-03-11
+> **Author**: GitHub Copilot (automated)
+> **Analyzer**: `CMSSW_15_0_15_JpsiJpsiPhi_refactor/src/HeavyFlavorAnalysis/TPS-Onia2MuMu/`
+> **Companion**: See `JpsiJpsiUps_Analysis_Plan.md` (v2.1) for full design rationale
+
+---
+
+## 0. Changes Applied in This Session
+
+### 0.1 Bug Fixes (Phase 2.5 — JpsiUpsPhi Pairing)
+
+| Bug ID | Description | Location | Fix |
+|--------|------------|----------|-----|
+| **A** | JpsiUpsPhi storage logic dumped all pairs into `Onia1_` | `pairMuons()` L696–710 | Split: JpsiJpsiPhi → all to Onia1; else → separated by `isOnia1`/`isOnia2` |
+| **B** | Quartet builder used upper-triangle `Onia1 × Onia1` for all channels | `pairMuons()` L720–752 | Added JpsiUpsPhi cross-product path `Onia1 × Onia2` |
+| **C** | `muPairCand_Onia2_` never cleared at start of `pairMuons()` | `pairMuons()` L639 | Added `muPairCand_Onia2_.clear()` |
+
+### 0.2 New Features
+
+| Phase | Feature | Files Modified |
+|-------|---------|---------------|
+| **1** | `MatchUpsTrigNames` member + TTree branch | `.h`, `.cc` (constructor, beginJob, clearEventData) |
+| **2** | Upsilon trigger matching in `processHLTInfo()` + `fillMuonBlock()` | `.cc` |
+| **3** | Per-resonance candidate pT/eta pre-cuts (6 new config params) | `.h`, `.cc`, both `.py` configs |
+| **4** | Sentinel values (`−999999`) for failed 3-body vertex fits | `.h` (decl), `.cc` (`storeSentinelPri()`, `combineCandidates()`) |
+
+### 0.3 Naming Clarification (planned, not yet applied)
+
+The variables `jpsiPairPtMin_`, `upsPairPtMin_`, `phiPairPtMin_` (and their `EtaMax` counterparts) are **ambiguous**: they could be misread as "the pT of a pair of J/ψ's" rather than "the pT of the dimuon/dikaon pair forming a single J/ψ/Υ/φ candidate."
+
+**Planned rename** (6 members + 6 config keys + 6 config values in 2 `.py` files):
+
+| Old C++ member | New C++ member | Old config key | New config key |
+|----------------|---------------|----------------|----------------|
+| `jpsiPairPtMin_` | `jpsiCandPtMin_` | `JpsiPairPtMin` | `JpsiCandPtMin` |
+| `jpsiPairEtaMax_` | `jpsiCandEtaMax_` | `JpsiPairEtaMax` | `JpsiCandEtaMax` |
+| `upsPairPtMin_` | `upsCandPtMin_` | `UpsPairPtMin` | `UpsCandPtMin` |
+| `upsPairEtaMax_` | `upsCandEtaMax_` | `UpsPairEtaMax` | `UpsCandEtaMax` |
+| `phiPairPtMin_` | `phiCandPtMin_` | `PhiPairPtMin` | `PhiCandPtMin` |
+| `phiPairEtaMax_` | `phiCandEtaMax_` | `PhiPairEtaMax` | `PhiCandEtaMax` |
+
+The word "Cand" (candidate) makes it clear that this is the pT of the **single composite candidate** (e.g., the dimuon system forming one J/ψ), not a pair of J/ψ candidates.
+
+**Files to modify**: `MultiLepPAT.h`, `MultiLepPAT.cc`, `ConfFile_cfg.py`, `runMultiLepPAT_MCRun3_miniAOD_Run2022.py`, and the corresponding header comment block.
+
+---
+
+## 1. MC Global Tag
+
+The MC samples used here are **Run3Summer22** (2022 pre-EE era). The correct global tags are:
+
+| Era | Global Tag |
+|-----|-----------|
+| 2022A / 2022B / 2022C / 2022D (pre-EE) | `130X_mcRun3_2022_realistic_v5` |
+| 2022E / 2022F / 2022G (post-EE) | `130X_mcRun3_2022_realistic_postEE_v6` |
+
+Since both of our test MC samples (`DPS-JpsiJpsi-Phi…Run3Summer22…` and `HO_DPS_JpsiJpsi_Y_Run3Summer22…`) are **pre-EE**, we use:
+
+```python
+process.GlobalTag = GlobalTag(process.GlobalTag, '130X_mcRun3_2022_realistic_v5', '')
+```
+
+**File**: `runMultiLepPAT_MCRun3_miniAOD_Run2022.py`, line ~59
+
+---
+
+## 2. Test Matrix
+
+| Test ID | Channel | Config (`AnalysisMode`) | Input | Output File |
+|---------|---------|------------------------|-------|-------------|
+| T1 | JpsiJpsiPhi | `"JpsiJpsiPhi"` | `DPS-JpsiJpsi-Phi1020_JJPhi_4Mu2K_…_MINIAOD_1497.root` (MC) | `/tmp/chiw_test_JpsiJpsiPhi.root` |
+| T2 | JpsiJpsiUps | `"JpsiJpsiUps"` | `HO_DPS_JpsiJpsi_Y_Run3Summer22_miniAOD_292.root` (MC) | `/tmp/chiw_test_JpsiJpsiUps.root` |
+| T3 | JpsiUpsPhi | `"JpsiUpsPhi"` | **Same collision data MINIAOD file used in current data validation** | `/tmp/chiw_test_JpsiUpsPhi_data.root` |
+| T3-MC (placeholder) | JpsiUpsPhi | `"JpsiUpsPhi"` | `JUPHI_MC_INPUT` (to be provided) | `/tmp/chiw_test_JpsiUpsPhi_mc.root` |
+
+### 2.1 Full File Paths
+
+```bash
+# JpsiJpsiPhi input
+JJPHI_INPUT="/eos/user/c/chiw/JpsiJpsiPhi/MC_samples/miniAOD/DPS-JpsiJpsi-Phi/filter_JPsi_PtMin6p0_Phi_PtMin6p0/DPS-JpsiJpsi-Phi1020_JJPhi_4Mu2K_13p6TeV_TuneCP5_pythia8_Run3Summer22_MINIAOD_1497.root"
+
+# JpsiJpsiUps input
+JJY_INPUT="/eos/user/c/chiw/JpsiJpsiUps/MC_samples/miniAOD/DPS-JpsiJpsi-Y/filter_JpsiPtMin4p0_YPtMin6p0/HO_DPS_JpsiJpsi_Y_Run3Summer22_miniAOD_292.root"
+
+# Collision data input (reuse the same file for JpsiJpsiUps/JpsiUpsPhi data-side checks)
+COLLISION_DATA_INPUT="root://cms-xrd-global.cern.ch//store/data/Run2023D/ParkingDoubleMuonLowMass0/MINIAOD/PromptReco-v1/000/369/873/00000/33e0e861-ddbc-4afe-a76b-31be5057dff1.root"
+
+# JpsiUpsPhi MC input (placeholder)
+JUPHI_MC_INPUT="file:/path/to/JpsiUpsPhi_MC_MINIAOD.root"
+
+# Working directory
+WORKDIR="/eos/user/c/chiw/JpsiJpsiPhi/CMSSW_15_0_15_JpsiJpsiPhi_refactor"
+TESTDIR="src/HeavyFlavorAnalysis/TPS-Onia2MuMu/test"
+```
+
+### 2.2 Known Issue: TFile::Write Abort
+
+When a ROOT file with the same output name already exists, ROOT may fail at final `TTree::Write()` with `FatalRootError: @SUB=TStorageFactoryFile::Write`, or may abort earlier in `beginJob()` while building streamer info, sometimes as a segmentation violation. **Always remove the output file before running or pass a unique `outputFile=`**.
+
+`ConfFile_cfg.py` appends the processed-event count to the requested output basename when `maxEvents` is positive. For example, `outputFile=/tmp/chiw/test.root maxEvents=50` writes `/tmp/chiw/test_numEvent50.root`, not `/tmp/chiw/test.root`. Use the suffixed filename for ROOT inspection and documentation tables.
+
+For the default configs, check `mymultilep.root` and `mymultilep_MC_DPS1.root` first:
+
+```bash
+rm -f /tmp/chiw_test_JpsiJpsiPhi.root
+rm -f /tmp/chiw_test_JpsiJpsiUps.root
+rm -f /tmp/chiw_test_JpsiUpsPhi_data.root
+rm -f /tmp/chiw_test_JpsiUpsPhi_mc.root
+```
+
+### 2.3 Known Issue: stale EDM plugin cache after adding a new module
+
+When a new EDAnalyzer or producer is added under `src/HeavyFlavorAnalysis/TPS-Onia2MuMu/src/`, a package-only rebuild may compile the plugin library successfully while the top-level runtime cache `lib/$SCRAM_ARCH/.edmplugincache` still misses the new module name. In that state `cmsRun` fails with:
+
+```text
+Exception Message:
+Unable to find plugin 'NEW_MODULE_NAME' in category 'CMS EDM Framework Module'
+```
+
+Observed workaround in this work area:
+
+```bash
+cd ${WORKDIR}
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+eval $(scramv1 runtime -sh)
+
+scram b clean
+scram b -j 4
+```
+
+After that full rebuild, verify the module appeared in the cache:
+
+```bash
+rg NEW_MODULE_NAME lib/${SCRAM_ARCH}/.edmplugincache
+```
+
+### 2.4 Known Issue: `root://store/...` may fail DNS resolution
+
+In this environment, using the shorthand XRootD URL form
+`root://store/...` caused `FileOpenError` failures with:
+
+```text
+getaddrinfo failed for 'store': Temporary failure in name resolution
+```
+
+Use the explicit global redirector instead:
+
+```bash
+root://cms-xrd-global.cern.ch//store/data/Run2023D/ParkingDoubleMuonLowMass0/MINIAOD/PromptReco-v1/000/369/873/00000/33e0e861-ddbc-4afe-a76b-31be5057dff1.root
+```
+
+---
+
+## 3. Test Execution Commands
+
+### 3.1 T1: JpsiJpsiPhi Channel
+
+Use `ConfFile_cfg.py` directly for current validation because it exposes the new
+single-object MC switches through `VarParsing`. For quick regression checks, run
+50 events first; full-file production can still use `maxEvents=-1` after the
+bounded test passes. These tests are now treated as efficiency-correction
+regression checks: they verify that object-level J/psi, Upsilon, and phi
+reconstruction is no longer biased by the full three-resonance candidate
+requirements.
+
+#### 3.1.1 Object-only single-object ntuple
+
+This validates that object-level `SingleJpsi_*` and `SinglePhi_*` branches are
+filled before final `JpsiJpsiPhi` composite construction. The `SingleUps_*`
+branch schema is also present after the efficiency-correction update, but it is
+expected to remain empty in `JpsiJpsiPhi` mode.
+
+```bash
+cd ${WORKDIR}
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+eval $(scramv1 runtime -sh)
+
+rm -f /tmp/chiw_test_JpsiJpsiPhi_single_object.root       /tmp/chiw_test_JpsiJpsiPhi_single_object_numEvent50.root
+# With maxEvents=50, inspect /tmp/chiw_test_JpsiJpsiPhi_single_object_numEvent50.root.
+
+cmsRun ${TESTDIR}/ConfFile_cfg.py     inputFiles=file:${JJPHI_INPUT}     outputFile=/tmp/chiw_test_JpsiJpsiPhi_single_object.root     maxEvents=50     analysisMode=JpsiJpsiPhi     runOnMC=True     era=Run2022     keepAllSingleObjectCandsInMC=True     skipCompositeCandBuildingWhenKeepingSingles=True     reportEvery=10
+```
+
+Expected behavior:
+- `SingleJpsi_*` and `SinglePhi_*` branches are present and can be non-empty.
+- `SingleUps_*` branches are present; `nSingleUpsCand == 0` is expected for `JpsiJpsiPhi`.
+- `Pri_*`, `Jpsi_1_*`, `Jpsi_2_*`, and `Phi_*` final-composite branches remain empty because `combineCandidates()` is intentionally skipped.
+- MC events are still written even without accepted final candidates.
+
+#### 3.1.2 Single-object branches plus nominal composite building
+
+This validates that enabling `KeepAllSingleObjectCandsInMC` can add object-level
+branches without changing the nominal final-composite path.
+
+```bash
+cd ${WORKDIR}
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+eval $(scramv1 runtime -sh)
+
+rm -f /tmp/chiw_test_JpsiJpsiPhi_single_object_composite.root       /tmp/chiw_test_JpsiJpsiPhi_single_object_composite_numEvent50.root
+# With maxEvents=50, inspect /tmp/chiw_test_JpsiJpsiPhi_single_object_composite_numEvent50.root.
+
+cmsRun ${TESTDIR}/ConfFile_cfg.py     inputFiles=file:${JJPHI_INPUT}     outputFile=/tmp/chiw_test_JpsiJpsiPhi_single_object_composite.root     maxEvents=50     analysisMode=JpsiJpsiPhi     runOnMC=True     era=Run2022     keepAllSingleObjectCandsInMC=True     skipCompositeCandBuildingWhenKeepingSingles=False     reportEvery=10
+```
+
+Expected behavior:
+- `SingleJpsi_*` and `SinglePhi_*` are filled before final composition.
+- `SingleUps_*` branches are present; `nSingleUpsCand == 0` is expected for `JpsiJpsiPhi`.
+- Final `Jpsi_1_*`, `Jpsi_2_*`, `Phi_*`, and `Pri_*` branches follow the nominal candidate-building path.
+- Failed 3-body fits, if any candidate reaches that stage and the fit fails, produce sentinel `Pri_mass = -999999`.
+
+### 3.2 T2: JpsiJpsiUps Channel
+
+Use `ConfFile_cfg.py` directly via VarParsing (`analysisMode`, `runOnMC`, `era`, `inputFiles`, `outputFile`).
+
+```bash
+cd ${WORKDIR}
+
+rm -f /tmp/chiw_test_JpsiJpsiUps.root
+
+cmsRun ${TESTDIR}/ConfFile_cfg.py \
+    inputFiles=file:${JJY_INPUT} \
+    outputFile=/tmp/chiw_test_JpsiJpsiUps.root \
+    analysisMode=JpsiJpsiUps \
+    runOnMC=True \
+    era=Run2022
+```
+
+Expected behavior:
+- AnalysisMode = `JpsiJpsiUps`
+- MinMuonCount = 6 (still enforced in analyzer constructor for this mode)
+- J/ψ pairs → `muPairCand_Onia1_`, Υ pairs → `muPairCand_Onia2_`
+- Quartets from upper-triangle of `Onia1_`
+- 3-body fit: `fit_Jpsi1 + fit_Jpsi2 + fit_Ups`
+- `Ups_*` branches populated; `Phi_*` branches empty
+
+### 3.3 T3: JpsiUpsPhi Channel (collision data test)
+
+Use the **same collision data MINIAOD input file** as your existing data-side validation. This is the requested default path for JpsiUpsPhi validation.
+
+```bash
+cd ${WORKDIR}
+
+rm -f /tmp/chiw_test_JpsiUpsPhi_data.root
+
+cmsRun ${TESTDIR}/ConfFile_cfg.py \
+    inputFiles=${COLLISION_DATA_INPUT} \
+    outputFile=/tmp/chiw_test_JpsiUpsPhi_data.root \
+    analysisMode=JpsiUpsPhi \
+    runOnMC=False \
+    era=Run2025C
+```
+
+Expected behavior:
+- AnalysisMode = `JpsiUpsPhi`
+- Data GT resolved from `ConfFile_cfg.py` via `era`
+- J/ψ in `Jpsi_1_*`, Υ in `Ups_*`, φ in `Phi_*`
+- Cross-combination path `Onia1 × Onia2` used before adding φ
+
+### 3.4 T3-MC: JpsiUpsPhi Channel (placeholder)
+
+```bash
+cd ${WORKDIR}
+
+rm -f /tmp/chiw_test_JpsiUpsPhi_mc.root
+
+cmsRun ${TESTDIR}/ConfFile_cfg.py \
+    inputFiles=${JUPHI_MC_INPUT} \
+    outputFile=/tmp/chiw_test_JpsiUpsPhi_mc.root \
+    analysisMode=JpsiUpsPhi \
+    runOnMC=True \
+    era=Run2022
+```
+
+> `JUPHI_MC_INPUT` is intentionally left as placeholder until dedicated JpsiUpsPhi MC is finalized.
+
+---
+
+## 4. Post-Run Validation Checks
+
+### 4.1 Event and Candidate Count (Mandatory)
+
+Do not use `tree.GetEntries("VectorBranch.size() > 0")` or
+`tree.Draw("VectorBranch.size()")` for these `std::vector` branches. In this
+CMSSW/ROOT environment that syntax can emit `TTreeFormula` warnings and return
+misleading counts. Use an explicit event loop instead.
+
+```python
+#!/usr/bin/env python3
+"""
+validate_ntuple.py — Check events and candidate multiplicities in X_data.
+Usage: python3 validate_ntuple.py /tmp/chiw_test_JpsiJpsiPhi_single_object_numEvent50.root
+"""
+import ROOT
+import sys
+
+fname = sys.argv[1]
+f = ROOT.TFile.Open(fname, "READ")
+if not f or f.IsZombie():
+    print(f"ERROR: Cannot open {fname}")
+    sys.exit(1)
+
+tree = f.Get("mkcands/X_data")
+if not tree:
+    print("ERROR: TTree 'mkcands/X_data' not found")
+    sys.exit(1)
+
+branches = {b.GetName() for b in tree.GetListOfBranches()}
+required = [
+    "nSingleJpsiCand", "SingleJpsi_mass",
+    "nSingleUpsCand", "SingleUps_mass",
+    "nSinglePhiCand", "SinglePhi_mass",
+    "MC_GenPart_pdgId",
+]
+missing = [name for name in required if name not in branches]
+if missing:
+    print(f"ERROR: Missing required branches: {missing}")
+    sys.exit(1)
+
+summary = {
+    "entries": tree.GetEntries(),
+    "events_with_single_jpsi": 0,
+    "total_single_jpsi": 0,
+    "max_single_jpsi": 0,
+    "events_with_single_phi": 0,
+    "total_single_phi": 0,
+    "max_single_phi": 0,
+    "events_with_final_pri": 0,
+    "total_final_pri": 0,
+    "max_final_pri": 0,
+    "events_with_Jpsi_1": 0,
+    "total_Jpsi_1": 0,
+    "events_with_Phi": 0,
+    "total_Phi": 0,
+    "sentinel_pri_events": 0,
+    "bad_single_jpsi_mu_indices": 0,
+    "negative_single_phi_track_indices": 0,
+    "single_jpsi_mu_gen_matches": 0,
+    "single_phi_kaon_gen_matches": 0,
+}
+
+for i in range(tree.GetEntries()):
+    tree.GetEntry(i)
+    n_single_jpsi = int(tree.nSingleJpsiCand)
+    n_single_phi = int(tree.nSinglePhiCand)
+    n_pri = int(tree.Pri_mass.size()) if "Pri_mass" in branches else 0
+    n_jpsi_1 = int(tree.Jpsi_1_mass.size()) if "Jpsi_1_mass" in branches else 0
+    n_phi = int(tree.Phi_mass.size()) if "Phi_mass" in branches else 0
+
+    summary["events_with_single_jpsi"] += n_single_jpsi > 0
+    summary["total_single_jpsi"] += n_single_jpsi
+    summary["max_single_jpsi"] = max(summary["max_single_jpsi"], n_single_jpsi)
+    summary["events_with_single_phi"] += n_single_phi > 0
+    summary["total_single_phi"] += n_single_phi
+    summary["max_single_phi"] = max(summary["max_single_phi"], n_single_phi)
+    summary["events_with_final_pri"] += n_pri > 0
+    summary["total_final_pri"] += n_pri
+    summary["max_final_pri"] = max(summary["max_final_pri"], n_pri)
+    summary["events_with_Jpsi_1"] += n_jpsi_1 > 0
+    summary["total_Jpsi_1"] += n_jpsi_1
+    summary["events_with_Phi"] += n_phi > 0
+    summary["total_Phi"] += n_phi
+    summary["sentinel_pri_events"] += any(x < -999000 for x in tree.Pri_mass)
+
+    for idx in tree.SingleJpsi_mu1_Idx:
+        summary["bad_single_jpsi_mu_indices"] += int(idx < 0 or idx >= tree.nMu)
+    for idx in tree.SingleJpsi_mu2_Idx:
+        summary["bad_single_jpsi_mu_indices"] += int(idx < 0 or idx >= tree.nMu)
+    for idx in tree.SinglePhi_K1_nonMuonTrackIdx:
+        summary["negative_single_phi_track_indices"] += int(idx < 0)
+    for idx in tree.SinglePhi_K2_nonMuonTrackIdx:
+        summary["negative_single_phi_track_indices"] += int(idx < 0)
+
+    summary["single_jpsi_mu_gen_matches"] += sum(
+        1 for x in tree.SingleJpsi_mu1_genMatchIdx if x >= 0)
+    summary["single_jpsi_mu_gen_matches"] += sum(
+        1 for x in tree.SingleJpsi_mu2_genMatchIdx if x >= 0)
+    summary["single_phi_kaon_gen_matches"] += sum(
+        1 for x in tree.SinglePhi_K1_genMatchIdx if x >= 0)
+    summary["single_phi_kaon_gen_matches"] += sum(
+        1 for x in tree.SinglePhi_K2_genMatchIdx if x >= 0)
+
+print(f"File: {fname}")
+for key, value in summary.items():
+    print(f"{key}={value}")
+
+f.Close()
+```
+
+### 4.2 Validation Plots (ROOT Macro)
+
+```python
+#!/usr/bin/env python3
+"""
+validation_plots.py — Produce validation plots from the MultiLepPAT ntuple.
+Usage: python3 validation_plots.py /tmp/chiw_test_JpsiJpsiPhi.root JpsiJpsiPhi
+"""
+import ROOT
+import sys
+import os
+
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat(111111)
+
+fname = sys.argv[1]
+channel = sys.argv[2] if len(sys.argv) > 2 else "JpsiJpsiPhi"
+outdir = f"/tmp/chiw_validation_{channel}"
+os.makedirs(outdir, exist_ok=True)
+
+f = ROOT.TFile.Open(fname, "READ")
+tree = f.Get("mkcands/X_data")
+
+plots = []
+
+# --- 1. J/psi_1 mass distribution ---
+c1 = ROOT.TCanvas("c_jpsi1_mass", "J/psi_1 mass", 800, 600)
+tree.Draw("Jpsi_1_mass>>h_jpsi1_mass(100, 2.8, 3.4)", "Jpsi_1_mass > 0")
+h = ROOT.gDirectory.Get("h_jpsi1_mass")
+h.SetTitle(f"J/#psi_{{1}} mass ({channel});m(#mu^{{+}}#mu^{{-}}) [GeV];Candidates")
+h.SetLineColor(ROOT.kBlue)
+h.SetLineWidth(2)
+c1.SaveAs(f"{outdir}/jpsi1_mass.png")
+plots.append("jpsi1_mass.png")
+
+# --- 2. J/psi_2 mass distribution ---
+c2 = ROOT.TCanvas("c_jpsi2_mass", "J/psi_2 mass", 800, 600)
+tree.Draw("Jpsi_2_mass>>h_jpsi2_mass(100, 2.8, 3.4)", "Jpsi_2_mass > 0")
+h = ROOT.gDirectory.Get("h_jpsi2_mass")
+h.SetTitle(f"J/#psi_{{2}} mass ({channel});m(#mu^{{+}}#mu^{{-}}) [GeV];Candidates")
+h.SetLineColor(ROOT.kRed)
+h.SetLineWidth(2)
+c2.SaveAs(f"{outdir}/jpsi2_mass.png")
+plots.append("jpsi2_mass.png")
+
+# --- 3. Channel-specific: Phi or Ups mass ---
+if channel in ("JpsiJpsiPhi", "JpsiUpsPhi"):
+    c3 = ROOT.TCanvas("c_phi_mass", "Phi mass", 800, 600)
+    tree.Draw("Phi_mass>>h_phi_mass(100, 0.95, 1.1)", "Phi_mass > 0")
+    h = ROOT.gDirectory.Get("h_phi_mass")
+    h.SetTitle(f"#phi mass ({channel});m(K^{{+}}K^{{-}}) [GeV];Candidates")
+    h.SetLineColor(ROOT.kGreen+2)
+    h.SetLineWidth(2)
+    c3.SaveAs(f"{outdir}/phi_mass.png")
+    plots.append("phi_mass.png")
+
+if channel in ("JpsiJpsiUps", "JpsiUpsPhi"):
+    c4 = ROOT.TCanvas("c_ups_mass", "Ups mass", 800, 600)
+    tree.Draw("Ups_mass>>h_ups_mass(100, 8.5, 10.5)", "Ups_mass > 0")
+    h = ROOT.gDirectory.Get("h_ups_mass")
+    h.SetTitle(f"#Upsilon mass ({channel});m(#mu^{{+}}#mu^{{-}}) [GeV];Candidates")
+    h.SetLineColor(ROOT.kMagenta)
+    h.SetLineWidth(2)
+    c4.SaveAs(f"{outdir}/ups_mass.png")
+    plots.append("ups_mass.png")
+
+# --- 4. Pri (3-body) mass distribution ---
+c5 = ROOT.TCanvas("c_pri_mass", "Primary vertex mass", 800, 600)
+tree.Draw("Pri_mass>>h_pri_mass(100, 0, 25)", "Pri_mass > 0")
+h = ROOT.gDirectory.Get("h_pri_mass")
+h.SetTitle(f"3-body combined mass ({channel});m [GeV];Candidates")
+h.SetLineColor(ROOT.kBlack)
+h.SetLineWidth(2)
+c5.SaveAs(f"{outdir}/pri_mass.png")
+plots.append("pri_mass.png")
+
+# --- 5. Candidate multiplicity per event ---
+c6 = ROOT.TCanvas("c_ncand", "Candidates per event", 800, 600)
+tree.Draw("Jpsi_1_mass.size()>>h_ncand(30, 0, 30)")
+h = ROOT.gDirectory.Get("h_ncand")
+h.SetTitle(f"Candidates per event ({channel});N_{{cand}};Events")
+h.SetLineColor(ROOT.kBlue)
+h.SetLineWidth(2)
+c6.SaveAs(f"{outdir}/ncand_per_event.png")
+plots.append("ncand_per_event.png")
+
+# --- 6. Pri_VtxProb distribution (including sentinel check) ---
+c7 = ROOT.TCanvas("c_pri_vtxprob", "Pri vertex probability", 800, 600)
+tree.Draw("Pri_VtxProb>>h_pri_vtxprob(100, -0.1, 1.1)", "Pri_VtxProb > -999000")
+h = ROOT.gDirectory.Get("h_pri_vtxprob")
+h.SetTitle(f"3-body vertex probability ({channel});VtxProb;Candidates")
+h.SetLineColor(ROOT.kBlack)
+h.SetLineWidth(2)
+c7.SaveAs(f"{outdir}/pri_vtxprob.png")
+plots.append("pri_vtxprob.png")
+
+# --- 7. Muon pT distribution ---
+c8 = ROOT.TCanvas("c_mu_pt", "Muon pT", 800, 600)
+tree.Draw("sqrt(muPx*muPx+muPy*muPy)>>h_mu_pt(100, 0, 30)")
+h = ROOT.gDirectory.Get("h_mu_pt")
+h.SetTitle(f"Muon p_{{T}} ({channel});p_{{T}}(#mu) [GeV];Muons")
+h.SetLineColor(ROOT.kBlue)
+h.SetLineWidth(2)
+c8.SaveAs(f"{outdir}/mu_pt.png")
+plots.append("mu_pt.png")
+
+# --- 8. Number of muons per event ---
+c9 = ROOT.TCanvas("c_nmu", "Muons per event", 800, 600)
+tree.Draw("nMu>>h_nmu(20, 0, 20)")
+h = ROOT.gDirectory.Get("h_nmu")
+h.SetTitle(f"Muon multiplicity ({channel});N_{{#mu}};Events")
+h.SetLineColor(ROOT.kRed)
+h.SetLineWidth(2)
+c9.SaveAs(f"{outdir}/nmu_per_event.png")
+plots.append("nmu_per_event.png")
+
+f.Close()
+
+print(f"\nValidation plots saved to: {outdir}/")
+for p in plots:
+    print(f"  - {p}")
+```
+
+### 4.3 Candidate Selection Strategy: Largest Σ pT²
+
+When there are multiple candidates in one event (often from overlapping final-state particles), the preferred strategy is to pick the candidate with the **largest sum of transverse momentum squared**:
+
+$$\text{Best candidate} = \underset{i}{\arg\max} \sum_{j \in \text{daughters}_i} p_{T,j}^2$$
+
+For JpsiJpsiPhi: $\Sigma p_T^2 = p_{T,J/\psi_1}^2 + p_{T,J/\psi_2}^2 + p_{T,\phi}^2$
+For JpsiJpsiUps: $\Sigma p_T^2 = p_{T,J/\psi_1}^2 + p_{T,J/\psi_2}^2 + p_{T,\Upsilon}^2$
+
+This is implemented in the **downstream analysis** (e.g., the Ntuple-correlator or flat-ntuple skimmer), not in the EDAnalyzer itself, since the ntuple stores all candidates. The validation script below checks the multiplicity to verify this pattern is present:
+
+```python
+#!/usr/bin/env python3
+"""
+check_best_candidate.py — Demonstrate the best-candidate selection using max sum-pT².
+This is an analysis-level operation, not done inside the EDAnalyzer.
+"""
+import ROOT
+import sys
+
+fname = sys.argv[1]
+channel = sys.argv[2] if len(sys.argv) > 2 else "JpsiJpsiPhi"
+
+f = ROOT.TFile.Open(fname, "READ")
+tree = f.Get("mkcands/X_data")
+
+n_multi = 0
+n_total = 0
+for i in range(tree.GetEntries()):
+    tree.GetEntry(i)
+    ncand = tree.Jpsi_1_mass.size()
+    if ncand == 0:
+        continue
+    n_total += 1
+    if ncand > 1:
+        n_multi += 1
+
+    # Find best candidate
+    best_idx = 0
+    best_sumpt2 = 0.0
+    for j in range(ncand):
+        pt1 = tree.Jpsi_1_pt[j]
+        pt2 = tree.Jpsi_2_pt[j]
+        if channel == "JpsiJpsiPhi":
+            pt3 = tree.Phi_pt[j] if tree.Phi_pt.size() > j else 0
+        elif channel == "JpsiJpsiUps":
+            pt3 = tree.Ups_pt[j] if tree.Ups_pt.size() > j else 0
+        else:
+            pt3 = 0
+        sumpt2 = pt1**2 + pt2**2 + pt3**2
+        if sumpt2 > best_sumpt2:
+            best_sumpt2 = sumpt2
+            best_idx = j
+    # In a real analysis, you would store only tree.*[best_idx]
+
+print(f"Total events with candidates: {n_total}")
+print(f"Events with >1 candidate:     {n_multi} ({100*n_multi/max(n_total,1):.1f}%)")
+f.Close()
+```
+
+---
+
+## 5. Expected Branch Structure
+
+### 5.1 JpsiJpsiPhi Mode
+
+| Branch group | Populated? | Notes |
+|-------------|-----------|-------|
+| `Jpsi_1_*` | ✅ Yes | First J/ψ in the quartet |
+| `Jpsi_2_*` | ✅ Yes | Second J/ψ in the quartet |
+| `Phi_*` | ✅ Yes | φ → K⁺K⁻ |
+| `Ups_*` | ❌ Empty | Not used in this mode |
+| `Pri_*` | ✅ Yes | 3-body combined fit (or sentinel −999999) |
+| `Phi_K_1_*`, `Phi_K_2_*` | ✅ Yes | Kaon tracks |
+| `MatchJpsiTriggerNames` | ✅ Yes | Matched J/ψ trigger paths |
+| `MatchUpsTriggerNames` | ✅ Yes (likely empty) | No Υ triggers expected in JJPhi MC |
+| `MC_GenPart_*` | ✅ Yes | Gen-level info (DoMonteCarloTree=True) |
+
+### 5.2 JpsiJpsiUps Mode
+
+| Branch group | Populated? | Notes |
+|-------------|-----------|-------|
+| `Jpsi_1_*` | ✅ Yes | First J/ψ from quartet |
+| `Jpsi_2_*` | ✅ Yes | Second J/ψ from quartet |
+| `Phi_*` | ❌ Empty | No tracks paired |
+| `Ups_*` | ✅ Yes | Υ from `muPairCand_Onia2_` |
+| `Pri_*` | ✅ Yes | 3-body combined fit (or sentinel) |
+| `Phi_K_*` | ❌ Empty | No kaons |
+| `MatchUpsTriggerNames` | ✅ Yes (may be empty) | Depends on HLT menu in MC |
+
+### 5.3 JpsiUpsPhi Mode
+
+| Branch group | Populated? | Notes |
+|-------------|-----------|-------|
+| `Jpsi_1_*` | ✅ Yes | J/ψ from `Onia1` |
+| `Ups_*` | ✅ Yes | Υ from `Onia2` |
+| `Phi_*` | ✅ Yes | φ candidate from track pairing |
+| `Jpsi_2_*` | ❌ Empty | Not used in this mode |
+| `Pri_*` | ✅ Yes | 3-body fit (or sentinel) |
+| `Phi_K_*` | ✅ Yes | Kaon tracks for φ |
+| `MatchJpsiTriggerNames` | ✅ Yes | J/ψ trigger matches |
+| `MatchUpsTriggerNames` | ✅ Yes | Υ trigger matches |
+
+---
+
+## 6. Troubleshooting
+
+### 6.1 TFile::Write Abort
+**Symptom**: `FatalRootError: @SUB=TStorageFactoryFile::Write`, abort signal at end of job.
+**Cause**: Output ROOT file already exists (especially on EOS).
+**Fix**: `rm -f <output_file>` before running.
+
+### 6.2 GlobalTag Not Found
+**Symptom**: `Global Tag "XXX" has not been found in the database`.
+**Fix**: Use `130X_mcRun3_2022_realistic_v5` for Run3Summer22 MC.
+
+### 6.3 Zero Candidates
+**Symptom**: TTree has entries but all candidate vectors are empty.
+**Possible causes**:
+- Mass windows too narrow (check `JpsiMassMin/Max`, `UpsMassMin/Max`)
+- `OniaDecayVtxProbCut` too tight
+- `MinMuonCount` too high for the MC sample
+- Per-resonance pT/eta cuts filtering everything (defaults are permissive: pT > 0, |η| < 999)
+
+### 6.4 Sentinel Values
+**Symptom**: `Pri_mass` contains `−999999`.
+**Explanation**: This is correct! It means the 3-body vertex fit failed but the individual 2-body resonance fits were valid. The individual resonance branches (Jpsi_1, Jpsi_2, Phi/Ups) still contain valid fit results.
+
+---
+
+## 7. Automated Test Script
+
+```bash
+#!/usr/bin/env bash
+# run_all_tests.sh — Run three channel tests and validate
+set -e
+
+WORKDIR="/eos/user/c/chiw/JpsiJpsiPhi/CMSSW_15_0_15_JpsiJpsiPhi_refactor"
+TESTDIR="src/HeavyFlavorAnalysis/TPS-Onia2MuMu/test"
+DOCDIR="src/HeavyFlavorAnalysis/TPS-Onia2MuMu/doc"
+
+JJPHI_INPUT="/eos/user/c/chiw/JpsiJpsiPhi/MC_samples/miniAOD/DPS-JpsiJpsi-Phi/filter_JPsi_PtMin6p0_Phi_PtMin6p0/DPS-JpsiJpsi-Phi1020_JJPhi_4Mu2K_13p6TeV_TuneCP5_pythia8_Run3Summer22_MINIAOD_1497.root"
+JJY_INPUT="/eos/user/c/chiw/JpsiJpsiUps/MC_samples/miniAOD/DPS-JpsiJpsi-Y/filter_JpsiPtMin4p0_YPtMin6p0/HO_DPS_JpsiJpsi_Y_Run3Summer22_miniAOD_292.root"
+COLLISION_DATA_INPUT="file:/path/to/the/same/collision_data_MINIAOD.root"
+JUPHI_MC_INPUT="file:/path/to/JpsiUpsPhi_MC_MINIAOD.root"
+
+cd ${WORKDIR}
+
+echo "=== T1: JpsiJpsiPhi ==="
+rm -f /tmp/chiw_test_JpsiJpsiPhi.root
+cmsRun ${TESTDIR}/runMultiLepPAT_MCRun3_miniAOD_Run2022.py \
+    inputFiles=file:${JJPHI_INPUT} \
+    outputFile=/tmp/chiw_test_JpsiJpsiPhi.root \
+    maxEvents=-1
+
+echo "=== T2: JpsiJpsiUps ==="
+rm -f /tmp/chiw_test_JpsiJpsiUps.root
+cmsRun ${TESTDIR}/ConfFile_cfg.py \
+    inputFiles=file:${JJY_INPUT} \
+    outputFile=/tmp/chiw_test_JpsiJpsiUps.root \
+    analysisMode=JpsiJpsiUps \
+    runOnMC=True \
+    era=Run2022
+
+echo "=== T3: JpsiUpsPhi (collision data) ==="
+rm -f /tmp/chiw_test_JpsiUpsPhi_data.root
+cmsRun ${TESTDIR}/ConfFile_cfg.py \
+    inputFiles=${COLLISION_DATA_INPUT} \
+    outputFile=/tmp/chiw_test_JpsiUpsPhi_data.root \
+    analysisMode=JpsiUpsPhi \
+    runOnMC=False \
+    era=Run2025C
+
+echo "=== T3-MC placeholder: JpsiUpsPhi ==="
+echo "Set JUPHI_MC_INPUT and uncomment below when MC is ready"
+# rm -f /tmp/chiw_test_JpsiUpsPhi_mc.root
+# cmsRun ${TESTDIR}/ConfFile_cfg.py \
+#     inputFiles=${JUPHI_MC_INPUT} \
+#     outputFile=/tmp/chiw_test_JpsiUpsPhi_mc.root \
+#     analysisMode=JpsiUpsPhi \
+#     runOnMC=True \
+#     era=Run2022
+
+echo "=== Validation ==="
+python3 ${DOCDIR}/validate_ntuple.py /tmp/chiw_test_JpsiJpsiPhi.root
+python3 ${DOCDIR}/validate_ntuple.py /tmp/chiw_test_JpsiJpsiUps.root
+python3 ${DOCDIR}/validate_ntuple.py /tmp/chiw_test_JpsiUpsPhi_data.root
+
+echo "=== Plots ==="
+python3 ${DOCDIR}/validation_plots.py /tmp/chiw_test_JpsiJpsiPhi.root JpsiJpsiPhi
+python3 ${DOCDIR}/validation_plots.py /tmp/chiw_test_JpsiJpsiUps.root JpsiJpsiUps
+python3 ${DOCDIR}/validation_plots.py /tmp/chiw_test_JpsiUpsPhi_data.root JpsiUpsPhi
+```
+
+---
+
+## 8. Actual Test Results (2026-03-11)
+
+> Tests executed after applying **all fixes** (Phases 1–4, Bugs A/B/C), **variable renaming**
+> (`jpsiPairPtMin_` → `jpsiCandPtMin_`, etc.), and **MC GlobalTag fix** (`130X_mcRun3_2022_realistic_v5`).
+
+### 8.1 Compilation
+
+- `scram b -j4` — **PASSED** (only `auto_ptr` deprecation warning from `VertexReProducer.h`)
+
+### 8.2 T1: JpsiJpsiPhi Channel
+
+| Metric | Value |
+|--------|-------|
+| Input MC file | `MINIAOD_1497.root` (DPS-JpsiJpsi-Phi, Run3Summer22) |
+| Input events | 945 |
+| Output file | `test_JpsiJpsiPhi.root` (7.8 MB) |
+| Output entries | 945 |
+| Number of branches | **200** |
+| Events with ≥1 candidate | **5** |
+| Total candidates | **6** |
+| Candidate multiplicity | 4 events × 1 cand, 1 event × 2 cands |
+| Sentinel values (Pri_mass < −999990) | **0** |
+| J/ψ₁ mass range | [3.0964, 3.1799] GeV |
+| J/ψ₂ mass range | [3.0129, 3.1634] GeV |
+| φ mass range | [1.0002, 1.1745] GeV |
+| 3-body mass range | [25.690, 63.877] GeV |
+| `Jpsi_1_count == Jpsi_2_count` per event | **945/945 ✅** (Bug A fix verified) |
+
+**Pipeline funnel:**
+
+```
+≥4 muons:              533 / 945
++ ≥1 Onia1 (J/ψ):       5
++ ≥1 Onia2 (J/ψ):       5
++ ≥1 Phi:                5
++ ≥1 Pri (3-body):       5
+```
+
+### 8.2.1 T1 Single-Object MC Efficiency Check (2026-06-03)
+
+> Tests executed after adding `KeepAllSingleObjectCandsInMC` and
+> `SkipCompositeCandBuildingWhenKeepingSingles`. Both commands used the same
+> valid JpsiJpsiPhi MINIAODSIM file listed in Section 2.1 and `maxEvents=50`.
+
+| Mode | Output file | Entries | Single J/ψ events / candidates | Single φ events / candidates | Final Pri events / candidates |
+|------|-------------|---------|--------------------------------|-------------------------------|-------------------------------|
+| object-only (`SkipComposite...=True`) | `/tmp/chiw_test_JpsiJpsiPhi_single_object_numEvent50.root` | 50 | 7 / 9 | 18 / 45 | 0 / 0 |
+| single-object + composite (`SkipComposite...=False`) | `/tmp/chiw_test_JpsiJpsiPhi_single_object_composite_numEvent50.root` | 50 | 7 / 9 | 18 / 45 | 1 / 2 |
+
+Additional checks:
+
+| Check | Object-only | Composite-enabled |
+|-------|-------------|-------------------|
+| Max `nSingleJpsiCand` | 2 | 2 |
+| Max `nSinglePhiCand` | 8 | 8 |
+| Bad `SingleJpsi_mu*_Idx` values | 0 | 0 |
+| Negative `SinglePhi_K*_nonMuonTrackIdx` values | 0 | 0 |
+| Matched single-J/ψ daughter muons | 18 | 18 |
+| Matched single-φ daughter kaons | 4 | 4 |
+| Sentinel `Pri_mass` events | 0 | 0 |
+
+Interpretation:
+
+- Object-only mode correctly writes MC events and object-level branches while leaving final-composite branches empty.
+- Composite-enabled mode preserves the nominal final-candidate path while adding the same single-object branch content.
+- The manual event-loop validator in Section 4.1 should be used for these counts; ROOT `TTreeFormula` vector `.size()` expressions are not reliable in this environment.
+
+### 8.2.2 T1 Efficiency-Correction Regression Check (2026-06-06)
+
+> Tests executed after refactoring `analyze()` so object-level reconstruction is
+> separated from full `JpsiJpsiPhi` candidate reconstruction. The purpose is an
+> efficiency-correction validation: single-resonance candidates must be available
+> for events that fail the full three-resonance topology. Both commands used the
+> Section 2.1 JpsiJpsiPhi MINIAODSIM file and `maxEvents=50`.
+
+| Mode | Output file | Entries | Single J/psi events / candidates | Single phi events / candidates | Single Ups events / candidates | Final Pri events / candidates |
+|------|-------------|---------|----------------------------------|--------------------------------|--------------------------------|-------------------------------|
+| object-only (`SkipComposite...=True`) | `/tmp/chiw/test_JpsiJpsiPhi_single_object_20260606_numEvent50.root` | 50 | 14 / 16 | 33 / 90 | 0 / 0 | 0 / 0 |
+| single-object + composite (`SkipComposite...=False`) | `/tmp/chiw/test_JpsiJpsiPhi_single_object_composite_20260606_numEvent50.root` | 50 | 14 / 16 | 33 / 90 | 0 / 0 | 1 / 2 |
+
+Additional checks:
+
+| Check | Object-only | Composite-enabled |
+|-------|-------------|-------------------|
+| Max `nSingleJpsiCand` | 2 | 2 |
+| Max `nSinglePhiCand` | 10 | 10 |
+| Max `nSingleUpsCand` | 0 | 0 |
+| Bad `SingleJpsi_mu*_Idx` values | 0 | 0 |
+| Negative `SinglePhi_K*_nonMuonTrackIdx` values | 0 | 0 |
+| Matched single-J/psi daughter muons | 32 | 32 |
+| Matched single-phi daughter kaons | 6 | 6 |
+| Sentinel `Pri_mass` events | 0 | 0 |
+
+Interpretation for efficiency corrections:
+
+- The larger single-object counts relative to the 2026-06-03 check are expected: single J/psi reconstruction no longer requires four reco muons, and single phi reconstruction no longer inherits the full muon-side requirement.
+- Object-only mode now isolates the single-resonance efficiency inputs while intentionally leaving final-composite branches empty.
+- Composite-enabled mode keeps the nominal full-candidate path and records the same single-object sideband needed for efficiency-factorization studies.
+- `SingleUps_*` branch schema is present for downstream code uniformity; it remains empty in `JpsiJpsiPhi` mode and should be validated separately with `JpsiUpsPhi` or `JpsiJpsiUps` input.
+
+### 8.3 T2: JpsiJpsiUps Channel
+
+| Metric | Value |
+|--------|-------|
+| Input MC file | `miniAOD_292.root` (DPS-JpsiJpsi-Y, Run3Summer22) |
+| Input events | 1000 |
+| Output file | `test_JpsiJpsiUps.root` (8.3 MB) |
+| Output entries | 1000 |
+| Number of branches | **200** |
+| Events with ≥1 candidate | **3** |
+| Total candidates | **3** |
+| Sentinel values | **0** |
+| J/ψ₁ mass range | [3.0674, 3.1137] GeV |
+| J/ψ₂ mass range | [3.0950, 3.1005] GeV |
+| Υ mass range | [9.4299, 9.4590] GeV |
+| 3-body mass range | [32.557, 78.591] GeV |
+| New Υ branches | `Ups_mass` ✅, `Ups_massDiff` ✅, `MatchUpsTriggerNames` ✅, `muIsUpsTrigMatch` ✅, `muIsUpsFilterMatch` ✅ |
+
+**Pipeline funnel:**
+
+```
+≥6 muons:              527 / 1000
++ ≥1 Onia1 (J/ψ):       3
++ ≥1 Onia2 (Υ):         3
++ ≥1 Pri (3-body):       3
+```
+
+### 8.4 Interpretation
+
+- **Low candidate yield** (0.3–0.5%) is physically expected:
+  the muon count includes all reco muons, but forming a good J/ψ or Υ pair
+  requires the mass window cut, opposite-charge, kinematic vertex fit with
+  non-negligible `VtxProb`, and `massDiff` quality selection.
+  Only a small fraction of the ~500 events with enough muons
+  produce valid resonance pairs passing all these criteria.
+- **Zero sentinel values** → all formed quartets successfully passed the 3-body
+  vertex fit. This is consistent with the low yield: only clean candidates survive.
+- **Bug A verification**: `Jpsi_1` and `Jpsi_2` vector sizes match for all 945 JpsiJpsiPhi events,
+  confirming the symmetric Onia1 ↔ Onia2 storage is working correctly.
+- **New branches verified**: All 5 Υ trigger/matching branches present and populated.
+
+### 8.5 Validation Plots
+
+14 plots generated in `validation_plots/`:
+
+| File | Content |
+|------|---------|
+| `JpsiJpsiPhi_mass.{png,pdf}` | J/ψ₁, J/ψ₂, φ, 3-body mass distributions |
+| `JpsiJpsiPhi_pt.{png,pdf}` | pT distributions for all resonances |
+| `JpsiJpsiPhi_multiplicity.{png,pdf}` | Candidate multiplicity per event |
+| `JpsiJpsiUps_mass.{png,pdf}` | J/ψ₁, J/ψ₂, Υ, 3-body mass distributions |
+| `JpsiJpsiUps_pt.{png,pdf}` | pT distributions for all resonances |
+| `JpsiJpsiUps_multiplicity.{png,pdf}` | Candidate multiplicity per event |
+| `Summary_comparison.{png,pdf}` | Side-by-side efficiency and yield comparison |

--- a/interface/MultiLepPAT.h
+++ b/interface/MultiLepPAT.h
@@ -867,6 +867,8 @@ private:
     vector<float> *RecoKaonTrack_dzAssocPV = nullptr, *RecoKaonTrack_dxyAssocPV = nullptr;
     vector<int>   *RecoKaonTrack_passDzPV = nullptr, *RecoKaonTrack_passDxyPV = nullptr;
     vector<int>   *RecoKaonTrack_passTrackPV = nullptr;
+    vector<float> *RecoKaonTrack_normalizedChi2 = nullptr;
+    vector<int>   *RecoKaonTrack_numberOfHits = nullptr, *RecoKaonTrack_isHighPurity = nullptr;
     vector<int>   *RecoKaonTrack_genMatchIdx = nullptr, *RecoKaonTrack_genMatchSource = nullptr;
     vector<float> *RecoKaonTrack_genMatchChi2 = nullptr;
     vector<int>   *RecoKaonTrack_usedInSinglePhi = nullptr;

--- a/interface/MultiLepPAT.h
+++ b/interface/MultiLepPAT.h
@@ -329,9 +329,9 @@ private:
     
     // Kinematics extraction (with and without uncertainties)
     static void getDynamics(const RefCountedKinematicParticle& arg_Part,
-                            double& res_pt, double& res_eta, double& res_phi);
+                            double& res_pt, double& res_eta, double& res_phi, double& res_y);
     static void getDynamics(double arg_mass, double arg_px, double arg_py, double arg_pz,
-                            double& res_pt, double& res_eta, double& res_phi);
+                            double& res_pt, double& res_eta, double& res_phi, double& res_y);
     // Momentum uncertainty extraction from kinematic fit covariance
     static void getMomentumErrors(const RefCountedKinematicParticle& arg_Part,
                                   double& res_pxErr, double& res_pyErr, double& res_pzErr,
@@ -449,6 +449,7 @@ private:
         vector<float>* br_Chi2, vector<float>* br_ndof, vector<float>* br_VtxProb,
         vector<float>* br_px, vector<float>* br_py, vector<float>* br_pz,
         vector<float>* br_phi, vector<float>* br_eta, vector<float>* br_pt,
+        vector<float>* br_y,
         vector<float>* br_pxErr, vector<float>* br_pyErr, vector<float>* br_pzErr,
         vector<float>* br_ptErr);
     std::pair<int, float> matchRecoMuonToStoredGenMuon(
@@ -774,9 +775,9 @@ private:
     vector<float> *Jpsi_2_ctau, *Jpsi_2_ctauErr, *Jpsi_2_Chi2, *Jpsi_2_ndof, *Jpsi_2_VtxProb;
     vector<float> *Phi_ctau, *Phi_ctauErr, *Phi_Chi2, *Phi_ndof, *Phi_VtxProb;
 
-    vector<float> *Jpsi_1_phi, *Jpsi_1_eta, *Jpsi_1_pt;
-    vector<float> *Jpsi_2_phi, *Jpsi_2_eta, *Jpsi_2_pt;
-    vector<float> *Phi_phi, *Phi_eta, *Phi_pt;
+    vector<float> *Jpsi_1_phi, *Jpsi_1_eta, *Jpsi_1_pt, *Jpsi_1_y;
+    vector<float> *Jpsi_2_phi, *Jpsi_2_eta, *Jpsi_2_pt, *Jpsi_2_y;
+    vector<float> *Phi_phi, *Phi_eta, *Phi_pt, *Phi_y;
 
     vector<float> *Jpsi_1_px, *Jpsi_1_py, *Jpsi_1_pz;
     vector<float> *Jpsi_2_px, *Jpsi_2_py, *Jpsi_2_pz;
@@ -795,7 +796,7 @@ private:
     vector<float> *SingleJpsi_ctau = nullptr, *SingleJpsi_ctauErr = nullptr;
     vector<float> *SingleJpsi_Chi2 = nullptr, *SingleJpsi_ndof = nullptr, *SingleJpsi_VtxProb = nullptr;
     vector<float> *SingleJpsi_px = nullptr, *SingleJpsi_py = nullptr, *SingleJpsi_pz = nullptr;
-    vector<float> *SingleJpsi_phi = nullptr, *SingleJpsi_eta = nullptr, *SingleJpsi_pt = nullptr;
+    vector<float> *SingleJpsi_phi = nullptr, *SingleJpsi_eta = nullptr, *SingleJpsi_pt = nullptr, *SingleJpsi_y = nullptr;
     vector<float> *SingleJpsi_pxErr = nullptr, *SingleJpsi_pyErr = nullptr;
     vector<float> *SingleJpsi_pzErr = nullptr, *SingleJpsi_ptErr = nullptr;
     vector<int>   *SingleJpsi_fitValid = nullptr, *SingleJpsi_fitPass = nullptr;
@@ -812,7 +813,7 @@ private:
     vector<float> *SingleUps_ctau = nullptr, *SingleUps_ctauErr = nullptr;
     vector<float> *SingleUps_Chi2 = nullptr, *SingleUps_ndof = nullptr, *SingleUps_VtxProb = nullptr;
     vector<float> *SingleUps_px = nullptr, *SingleUps_py = nullptr, *SingleUps_pz = nullptr;
-    vector<float> *SingleUps_phi = nullptr, *SingleUps_eta = nullptr, *SingleUps_pt = nullptr;
+    vector<float> *SingleUps_phi = nullptr, *SingleUps_eta = nullptr, *SingleUps_pt = nullptr, *SingleUps_y = nullptr;
     vector<float> *SingleUps_pxErr = nullptr, *SingleUps_pyErr = nullptr;
     vector<float> *SingleUps_pzErr = nullptr, *SingleUps_ptErr = nullptr;
     vector<int>   *SingleUps_fitValid = nullptr, *SingleUps_fitPass = nullptr;
@@ -830,7 +831,7 @@ private:
     vector<float> *SinglePhi_ctau = nullptr, *SinglePhi_ctauErr = nullptr;
     vector<float> *SinglePhi_Chi2 = nullptr, *SinglePhi_ndof = nullptr, *SinglePhi_VtxProb = nullptr;
     vector<float> *SinglePhi_px = nullptr, *SinglePhi_py = nullptr, *SinglePhi_pz = nullptr;
-    vector<float> *SinglePhi_phi = nullptr, *SinglePhi_eta = nullptr, *SinglePhi_pt = nullptr;
+    vector<float> *SinglePhi_phi = nullptr, *SinglePhi_eta = nullptr, *SinglePhi_pt = nullptr, *SinglePhi_y = nullptr;
     vector<float> *SinglePhi_pxErr = nullptr, *SinglePhi_pyErr = nullptr;
     vector<float> *SinglePhi_pzErr = nullptr, *SinglePhi_ptErr = nullptr;
     vector<int>   *SinglePhi_fitValid = nullptr, *SinglePhi_fitPass = nullptr;
@@ -874,7 +875,7 @@ private:
     vector<float> *Pri_mass, *Pri_massErr;
     vector<float> *Pri_ctau, *Pri_ctauErr, *Pri_Chi2, *Pri_ndof, *Pri_VtxProb;
     vector<float> *Pri_px, *Pri_py, *Pri_pz;
-    vector<float> *Pri_phi, *Pri_eta, *Pri_pt;
+    vector<float> *Pri_phi, *Pri_eta, *Pri_pt, *Pri_y;
     vector<float> *Pri_pxErr, *Pri_pyErr, *Pri_pzErr, *Pri_ptErr;
     vector<int>   *Pri_fitValid, *Pri_fitPass, *Pri_assocPVPass, *Pri_assocPVIdx, *Pri_trackPVPass, *Pri_passAny;
     vector<float> *Pri_maxAbsDzPV, *Pri_maxAbsDxyPV;
@@ -907,7 +908,7 @@ private:
     vector<float> *Ups_mass, *Ups_massErr, *Ups_massDiff;
     vector<float> *Ups_ctau, *Ups_ctauErr, *Ups_Chi2, *Ups_ndof, *Ups_VtxProb;
     vector<float> *Ups_px, *Ups_py, *Ups_pz;
-    vector<float> *Ups_phi, *Ups_eta, *Ups_pt;
+    vector<float> *Ups_phi, *Ups_eta, *Ups_pt, *Ups_y;
     vector<float> *Ups_pxErr, *Ups_pyErr, *Ups_pzErr, *Ups_ptErr;
 
     // ======================== MC gen-level branches ========================

--- a/interface/MultiLepPAT.h
+++ b/interface/MultiLepPAT.h
@@ -763,7 +763,6 @@ private:
     // -- Resonance candidate indices --
     vector<float> *Jpsi_1_mu_1_Idx, *Jpsi_1_mu_2_Idx;
     vector<float> *Jpsi_2_mu_1_Idx, *Jpsi_2_mu_2_Idx;
-    vector<float> *Phi_K_1_Idx, *Phi_K_2_Idx;
     vector<int>   *Phi_K_1_RecoKaonTrackIdx = nullptr, *Phi_K_2_RecoKaonTrackIdx = nullptr;
     // [Comment] Storing raw dxy and dz values for muons and the fitted candidates is good redundancy.
     // -- Reconstructed resonances: mass, vertex, kinematics --
@@ -837,7 +836,6 @@ private:
     vector<int>   *SinglePhi_fitValid = nullptr, *SinglePhi_fitPass = nullptr;
     vector<float> *SinglePhi_prefitMass = nullptr, *SinglePhi_prefitPt = nullptr;
     vector<float> *SinglePhi_prefitEta = nullptr, *SinglePhi_prefitPhi = nullptr;
-    vector<int>   *SinglePhi_K1_nonMuonTrackIdx = nullptr, *SinglePhi_K2_nonMuonTrackIdx = nullptr;
     vector<int>   *SinglePhi_K1_RecoKaonTrackIdx = nullptr, *SinglePhi_K2_RecoKaonTrackIdx = nullptr;
     vector<int>   *SinglePhi_K1_charge = nullptr, *SinglePhi_K2_charge = nullptr;
     vector<float> *SinglePhi_K1_pt = nullptr, *SinglePhi_K1_eta = nullptr, *SinglePhi_K1_phi = nullptr;
@@ -859,7 +857,6 @@ private:
     vector<float> *SinglePhi_maxAbsDzPV = nullptr, *SinglePhi_maxAbsDxyPV = nullptr;
 
     // RecoKaonTrack block: lightweight per-track storage for phi/kaon efficiency
-    vector<int>   *RecoKaonTrack_nonMuonTrackIdx = nullptr;
     vector<float> *RecoKaonTrack_pt = nullptr, *RecoKaonTrack_eta = nullptr, *RecoKaonTrack_phi = nullptr;
     vector<float> *RecoKaonTrack_px = nullptr, *RecoKaonTrack_py = nullptr, *RecoKaonTrack_pz = nullptr;
     vector<int>   *RecoKaonTrack_charge = nullptr;

--- a/interface/MultiLepPAT.h
+++ b/interface/MultiLepPAT.h
@@ -453,6 +453,11 @@ private:
         unsigned int muIdx,
         const edm::Handle<reco::GenParticleCollection>& genParticles,
         int requiredMotherPdgId) const;
+    int findCommonStoredGenMotherIdx(
+        int daughter1StoredIdx,
+        int daughter2StoredIdx,
+        int requiredMotherPdgId,
+        const edm::Handle<reco::GenParticleCollection>& genParticles) const;
 
     // Store sentinel values for failed 3-body vertex fit
     void storeSentinelPri();
@@ -604,6 +609,7 @@ private:
     unsigned long long currentEvent_;
     std::vector<edm::View<pat::PackedCandidate>::const_iterator> nonMuonTrack_;
     std::unordered_map<unsigned int, int> handleToNtupleIndex_;
+    std::unordered_map<int, unsigned int> ntupleToHandleIndex_;
     
     // Muon pair candidates
     std::vector<muList_t> muPairCand_Onia1_;  // J/psi (or 1st quarkonium)
@@ -794,6 +800,7 @@ private:
     vector<float> *SingleJpsi_prefitEta = nullptr, *SingleJpsi_prefitPhi = nullptr;
     vector<int>   *SingleJpsi_mu1_Idx = nullptr, *SingleJpsi_mu2_Idx = nullptr;
     vector<int>   *SingleJpsi_mu1_charge = nullptr, *SingleJpsi_mu2_charge = nullptr;
+    vector<int>   *SingleJpsi_genMatchIdx = nullptr;
     vector<int>   *SingleJpsi_mu1_genMatchIdx = nullptr, *SingleJpsi_mu2_genMatchIdx = nullptr;
     vector<float> *SingleJpsi_mu1_genMatchChi2 = nullptr, *SingleJpsi_mu2_genMatchChi2 = nullptr;
 
@@ -810,6 +817,7 @@ private:
     vector<float> *SingleUps_prefitEta = nullptr, *SingleUps_prefitPhi = nullptr;
     vector<int>   *SingleUps_mu1_Idx = nullptr, *SingleUps_mu2_Idx = nullptr;
     vector<int>   *SingleUps_mu1_charge = nullptr, *SingleUps_mu2_charge = nullptr;
+    vector<int>   *SingleUps_genMatchIdx = nullptr;
     vector<int>   *SingleUps_mu1_genMatchIdx = nullptr, *SingleUps_mu2_genMatchIdx = nullptr;
     vector<float> *SingleUps_mu1_genMatchChi2 = nullptr, *SingleUps_mu2_genMatchChi2 = nullptr;
 
@@ -836,6 +844,7 @@ private:
     vector<int>   *SinglePhi_K1_passTrackPV = nullptr, *SinglePhi_K2_passTrackPV = nullptr;
     vector<float> *SinglePhi_K1_dzPV = nullptr, *SinglePhi_K2_dzPV = nullptr;
     vector<float> *SinglePhi_K1_dxyPV = nullptr, *SinglePhi_K2_dxyPV = nullptr;
+    vector<int>   *SinglePhi_genMatchIdx = nullptr;
     vector<int>   *SinglePhi_K1_genMatchIdx = nullptr, *SinglePhi_K2_genMatchIdx = nullptr;
     vector<int>   *SinglePhi_K1_genMatchSource = nullptr, *SinglePhi_K2_genMatchSource = nullptr;
     vector<float> *SinglePhi_K1_genMatchChi2 = nullptr, *SinglePhi_K2_genMatchChi2 = nullptr;

--- a/interface/MultiLepPAT.h
+++ b/interface/MultiLepPAT.h
@@ -511,7 +511,12 @@ private:
     // -- Track (kaon/pion) selection (StringCutObjectSelector based) --
     std::string trackSelectionStr_;
     StringCutObjectSelector<pat::PackedCandidate> trackSelector_;
-    
+
+    // -- Track quality selection (applied to bestTrack() for phi reconstruction) --
+    std::string trackQualityStr_;
+    StringCutObjectSelector<reco::Track> trackQualitySelector_;
+    bool requireRecoKaonTrackHighPurity_;
+
     // -- Primary vertex quality cuts (configurable) --
     int    pvNdofMin_;
     double pvMaxAbsZ_;

--- a/interface/MultiLepPAT.h
+++ b/interface/MultiLepPAT.h
@@ -307,7 +307,7 @@ private:
     void storeSingleUpsCandidatesForMC(
         const reco::Vertex& beamSpotV,
         const edm::Handle<reco::GenParticleCollection>& genParticles);
-    void fillRecoKaonTrackBlockForMC(
+    void fillRecoKaonTrackBlock(
         const edm::Handle<reco::GenParticleCollection>& genParticles);
     void storeSinglePhiCandidatesForMC(
         const reco::Vertex& beamSpotV,

--- a/interface/MultiLepPAT.h
+++ b/interface/MultiLepPAT.h
@@ -764,6 +764,7 @@ private:
     vector<float> *Jpsi_1_mu_1_Idx, *Jpsi_1_mu_2_Idx;
     vector<float> *Jpsi_2_mu_1_Idx, *Jpsi_2_mu_2_Idx;
     vector<float> *Phi_K_1_Idx, *Phi_K_2_Idx;
+    vector<int>   *Phi_K_1_RecoKaonTrackIdx = nullptr, *Phi_K_2_RecoKaonTrackIdx = nullptr;
     // [Comment] Storing raw dxy and dz values for muons and the fitted candidates is good redundancy.
     // -- Reconstructed resonances: mass, vertex, kinematics --
     vector<float> *Jpsi_1_mass, *Jpsi_1_massErr, *Jpsi_1_massDiff;
@@ -837,6 +838,7 @@ private:
     vector<float> *SinglePhi_prefitMass = nullptr, *SinglePhi_prefitPt = nullptr;
     vector<float> *SinglePhi_prefitEta = nullptr, *SinglePhi_prefitPhi = nullptr;
     vector<int>   *SinglePhi_K1_nonMuonTrackIdx = nullptr, *SinglePhi_K2_nonMuonTrackIdx = nullptr;
+    vector<int>   *SinglePhi_K1_RecoKaonTrackIdx = nullptr, *SinglePhi_K2_RecoKaonTrackIdx = nullptr;
     vector<int>   *SinglePhi_K1_charge = nullptr, *SinglePhi_K2_charge = nullptr;
     vector<float> *SinglePhi_K1_pt = nullptr, *SinglePhi_K1_eta = nullptr, *SinglePhi_K1_phi = nullptr;
     vector<float> *SinglePhi_K2_pt = nullptr, *SinglePhi_K2_eta = nullptr, *SinglePhi_K2_phi = nullptr;

--- a/interface/MultiLepPAT.h
+++ b/interface/MultiLepPAT.h
@@ -304,6 +304,9 @@ private:
     void storeSingleJpsiCandidatesForMC(
         const reco::Vertex& beamSpotV,
         const edm::Handle<reco::GenParticleCollection>& genParticles);
+    void storeSingleUpsCandidatesForMC(
+        const reco::Vertex& beamSpotV,
+        const edm::Handle<reco::GenParticleCollection>& genParticles);
     void storeSinglePhiCandidatesForMC(
         const reco::Vertex& beamSpotV,
         const edm::Handle<reco::GenParticleCollection>& genParticles);
@@ -449,7 +452,7 @@ private:
     std::pair<int, float> matchRecoMuonToStoredGenMuon(
         unsigned int muIdx,
         const edm::Handle<reco::GenParticleCollection>& genParticles,
-        bool requireJpsiMother) const;
+        int requiredMotherPdgId) const;
 
     // Store sentinel values for failed 3-body vertex fit
     void storeSentinelPri();
@@ -793,6 +796,22 @@ private:
     vector<int>   *SingleJpsi_mu1_charge = nullptr, *SingleJpsi_mu2_charge = nullptr;
     vector<int>   *SingleJpsi_mu1_genMatchIdx = nullptr, *SingleJpsi_mu2_genMatchIdx = nullptr;
     vector<float> *SingleJpsi_mu1_genMatchChi2 = nullptr, *SingleJpsi_mu2_genMatchChi2 = nullptr;
+
+    int nSingleUpsCand = 0;
+    vector<float> *SingleUps_mass = nullptr, *SingleUps_massErr = nullptr, *SingleUps_massDiff = nullptr;
+    vector<float> *SingleUps_ctau = nullptr, *SingleUps_ctauErr = nullptr;
+    vector<float> *SingleUps_Chi2 = nullptr, *SingleUps_ndof = nullptr, *SingleUps_VtxProb = nullptr;
+    vector<float> *SingleUps_px = nullptr, *SingleUps_py = nullptr, *SingleUps_pz = nullptr;
+    vector<float> *SingleUps_phi = nullptr, *SingleUps_eta = nullptr, *SingleUps_pt = nullptr;
+    vector<float> *SingleUps_pxErr = nullptr, *SingleUps_pyErr = nullptr;
+    vector<float> *SingleUps_pzErr = nullptr, *SingleUps_ptErr = nullptr;
+    vector<int>   *SingleUps_fitValid = nullptr, *SingleUps_fitPass = nullptr;
+    vector<float> *SingleUps_prefitMass = nullptr, *SingleUps_prefitPt = nullptr;
+    vector<float> *SingleUps_prefitEta = nullptr, *SingleUps_prefitPhi = nullptr;
+    vector<int>   *SingleUps_mu1_Idx = nullptr, *SingleUps_mu2_Idx = nullptr;
+    vector<int>   *SingleUps_mu1_charge = nullptr, *SingleUps_mu2_charge = nullptr;
+    vector<int>   *SingleUps_mu1_genMatchIdx = nullptr, *SingleUps_mu2_genMatchIdx = nullptr;
+    vector<float> *SingleUps_mu1_genMatchChi2 = nullptr, *SingleUps_mu2_genMatchChi2 = nullptr;
 
     int nSinglePhiCand = 0;
     vector<float> *SinglePhi_mass = nullptr, *SinglePhi_massErr = nullptr, *SinglePhi_massDiff = nullptr;

--- a/interface/MultiLepPAT.h
+++ b/interface/MultiLepPAT.h
@@ -307,6 +307,8 @@ private:
     void storeSingleUpsCandidatesForMC(
         const reco::Vertex& beamSpotV,
         const edm::Handle<reco::GenParticleCollection>& genParticles);
+    void fillRecoKaonTrackBlockForMC(
+        const edm::Handle<reco::GenParticleCollection>& genParticles);
     void storeSinglePhiCandidatesForMC(
         const reco::Vertex& beamSpotV,
         const edm::Handle<reco::GenParticleCollection>& genParticles);
@@ -610,6 +612,7 @@ private:
     std::vector<edm::View<pat::PackedCandidate>::const_iterator> nonMuonTrack_;
     std::unordered_map<unsigned int, int> handleToNtupleIndex_;
     std::unordered_map<int, unsigned int> ntupleToHandleIndex_;
+    std::unordered_map<unsigned int, int> nonMuonTrackIdxToRecoKaonTrackIdx_;
     
     // Muon pair candidates
     std::vector<muList_t> muPairCand_Onia1_;  // J/psi (or 1st quarkonium)
@@ -822,6 +825,7 @@ private:
     vector<float> *SingleUps_mu1_genMatchChi2 = nullptr, *SingleUps_mu2_genMatchChi2 = nullptr;
 
     int nSinglePhiCand = 0;
+    int nRecoKaonTrack = 0;
     vector<float> *SinglePhi_mass = nullptr, *SinglePhi_massErr = nullptr, *SinglePhi_massDiff = nullptr;
     vector<float> *SinglePhi_ctau = nullptr, *SinglePhi_ctauErr = nullptr;
     vector<float> *SinglePhi_Chi2 = nullptr, *SinglePhi_ndof = nullptr, *SinglePhi_VtxProb = nullptr;
@@ -851,7 +855,22 @@ private:
     vector<int>   *SinglePhi_commonAssocPVPass = nullptr, *SinglePhi_commonAssocPVIdx = nullptr;
     vector<int>   *SinglePhi_trackPVPass = nullptr, *SinglePhi_vertexCriteriaPass = nullptr;
     vector<float> *SinglePhi_maxAbsDzPV = nullptr, *SinglePhi_maxAbsDxyPV = nullptr;
-    
+
+    // RecoKaonTrack block: lightweight per-track storage for phi/kaon efficiency
+    vector<int>   *RecoKaonTrack_nonMuonTrackIdx = nullptr;
+    vector<float> *RecoKaonTrack_pt = nullptr, *RecoKaonTrack_eta = nullptr, *RecoKaonTrack_phi = nullptr;
+    vector<float> *RecoKaonTrack_px = nullptr, *RecoKaonTrack_py = nullptr, *RecoKaonTrack_pz = nullptr;
+    vector<int>   *RecoKaonTrack_charge = nullptr;
+    vector<int>   *RecoKaonTrack_fromPV = nullptr, *RecoKaonTrack_pvAssocQuality = nullptr;
+    vector<int>   *RecoKaonTrack_vertexId = nullptr;
+    vector<float> *RecoKaonTrack_dzPV = nullptr, *RecoKaonTrack_dxyPV = nullptr;
+    vector<float> *RecoKaonTrack_dzAssocPV = nullptr, *RecoKaonTrack_dxyAssocPV = nullptr;
+    vector<int>   *RecoKaonTrack_passDzPV = nullptr, *RecoKaonTrack_passDxyPV = nullptr;
+    vector<int>   *RecoKaonTrack_passTrackPV = nullptr;
+    vector<int>   *RecoKaonTrack_genMatchIdx = nullptr, *RecoKaonTrack_genMatchSource = nullptr;
+    vector<float> *RecoKaonTrack_genMatchChi2 = nullptr;
+    vector<int>   *RecoKaonTrack_usedInSinglePhi = nullptr;
+
     // -- Primary (combined) vertex --
     vector<float> *Pri_mass, *Pri_massErr;
     vector<float> *Pri_ctau, *Pri_ctauErr, *Pri_Chi2, *Pri_ndof, *Pri_VtxProb;

--- a/src/MultiLepPAT.cc
+++ b/src/MultiLepPAT.cc
@@ -450,6 +450,8 @@ MultiLepPAT::MultiLepPAT(const edm::ParameterSet &iConfig)
       RecoKaonTrack_dzAssocPV(new vector<float>()), RecoKaonTrack_dxyAssocPV(new vector<float>()),
       RecoKaonTrack_passDzPV(new vector<int>()), RecoKaonTrack_passDxyPV(new vector<int>()),
       RecoKaonTrack_passTrackPV(new vector<int>()),
+      RecoKaonTrack_normalizedChi2(new vector<float>()),
+      RecoKaonTrack_numberOfHits(new vector<int>()), RecoKaonTrack_isHighPurity(new vector<int>()),
       RecoKaonTrack_genMatchIdx(new vector<int>()), RecoKaonTrack_genMatchSource(new vector<int>()),
       RecoKaonTrack_genMatchChi2(new vector<float>()),
       RecoKaonTrack_usedInSinglePhi(new vector<int>()),
@@ -1844,6 +1846,8 @@ void MultiLepPAT::fillRecoKaonTrackBlock(
     RecoKaonTrack_dzAssocPV->clear(); RecoKaonTrack_dxyAssocPV->clear();
     RecoKaonTrack_passDzPV->clear(); RecoKaonTrack_passDxyPV->clear();
     RecoKaonTrack_passTrackPV->clear();
+    RecoKaonTrack_normalizedChi2->clear();
+    RecoKaonTrack_numberOfHits->clear(); RecoKaonTrack_isHighPurity->clear();
     RecoKaonTrack_genMatchIdx->clear(); RecoKaonTrack_genMatchSource->clear();
     RecoKaonTrack_genMatchChi2->clear();
     RecoKaonTrack_usedInSinglePhi->clear();
@@ -1893,6 +1897,8 @@ void MultiLepPAT::fillRecoKaonTrackBlock(
         const auto diagnostics = (cacheIt != diagnosticsCache.end())
             ? cacheIt->second
             : buildPhiKaonDiagnostics(cand, thePrimaryV_, genParticles);
+        const reco::Track* bestTrack =
+            (cand.hasTrackDetails() && cand.bestTrack() != nullptr) ? cand.bestTrack() : nullptr;
 
         nonMuonTrackIdxToRecoKaonTrackIdx_[nonMuonIdx] = nRecoKaonTrack;
         RecoKaonTrack_pt->push_back(cand.pt());
@@ -1912,6 +1918,10 @@ void MultiLepPAT::fillRecoKaonTrackBlock(
         RecoKaonTrack_passDzPV->push_back(diagnostics.passDzPV ? 1 : 0);
         RecoKaonTrack_passDxyPV->push_back(diagnostics.passDxyPV ? 1 : 0);
         RecoKaonTrack_passTrackPV->push_back(diagnostics.passTrackPV ? 1 : 0);
+        RecoKaonTrack_normalizedChi2->push_back(bestTrack != nullptr ? bestTrack->normalizedChi2() : -1.f);
+        RecoKaonTrack_numberOfHits->push_back(bestTrack != nullptr ? bestTrack->numberOfValidHits() : -1);
+        RecoKaonTrack_isHighPurity->push_back(
+            bestTrack != nullptr && bestTrack->quality(reco::Track::highPurity) ? 1 : 0);
         RecoKaonTrack_genMatchIdx->push_back(diagnostics.genMatchIdx);
         RecoKaonTrack_genMatchSource->push_back(diagnostics.genMatchSource);
         RecoKaonTrack_genMatchChi2->push_back(diagnostics.genMatchChi2);
@@ -3423,6 +3433,8 @@ void MultiLepPAT::clearEventData()
     RecoKaonTrack_dzAssocPV->clear(); RecoKaonTrack_dxyAssocPV->clear();
     RecoKaonTrack_passDzPV->clear(); RecoKaonTrack_passDxyPV->clear();
     RecoKaonTrack_passTrackPV->clear();
+    RecoKaonTrack_normalizedChi2->clear();
+    RecoKaonTrack_numberOfHits->clear(); RecoKaonTrack_isHighPurity->clear();
     RecoKaonTrack_genMatchIdx->clear(); RecoKaonTrack_genMatchSource->clear();
     RecoKaonTrack_genMatchChi2->clear();
     RecoKaonTrack_usedInSinglePhi->clear();
@@ -4527,6 +4539,9 @@ void MultiLepPAT::beginJob()
     X_One_Tree_->Branch("RecoKaonTrack_passDzPV", &RecoKaonTrack_passDzPV);
     X_One_Tree_->Branch("RecoKaonTrack_passDxyPV", &RecoKaonTrack_passDxyPV);
     X_One_Tree_->Branch("RecoKaonTrack_passTrackPV", &RecoKaonTrack_passTrackPV);
+    X_One_Tree_->Branch("RecoKaonTrack_normalizedChi2", &RecoKaonTrack_normalizedChi2);
+    X_One_Tree_->Branch("RecoKaonTrack_numberOfHits", &RecoKaonTrack_numberOfHits);
+    X_One_Tree_->Branch("RecoKaonTrack_isHighPurity", &RecoKaonTrack_isHighPurity);
     X_One_Tree_->Branch("RecoKaonTrack_genMatchIdx", &RecoKaonTrack_genMatchIdx);
     X_One_Tree_->Branch("RecoKaonTrack_genMatchSource", &RecoKaonTrack_genMatchSource);
     X_One_Tree_->Branch("RecoKaonTrack_genMatchChi2", &RecoKaonTrack_genMatchChi2);

--- a/src/MultiLepPAT.cc
+++ b/src/MultiLepPAT.cc
@@ -776,6 +776,7 @@ void MultiLepPAT::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetu
 void MultiLepPAT::processMCGenInfo(const edm::Event &iEvent)
 {
     handleToNtupleIndex_.clear();
+    ntupleToHandleIndex_.clear();
 
     edm::Handle<reco::GenParticleCollection> genParticles;
     iEvent.getByToken(genParticlesToken_, genParticles);
@@ -821,6 +822,7 @@ void MultiLepPAT::processMCGenInfo(const edm::Event &iEvent)
                 MC_GenPart_eta->push_back(particle.eta());
                 MC_GenPart_phi->push_back(particle.phi());
                 handleToNtupleIndex_[i] = ntupleIndex;
+                ntupleToHandleIndex_[ntupleIndex] = static_cast<unsigned int>(i);
                 storedHandleIndices.push_back(i);
             }
         }
@@ -1925,6 +1927,8 @@ void MultiLepPAT::storeSingleJpsiCandidatesForMC(
         SingleJpsi_mu2_genMatchIdx->push_back(mu2Match.first);
         SingleJpsi_mu1_genMatchChi2->push_back(mu1Match.second);
         SingleJpsi_mu2_genMatchChi2->push_back(mu2Match.second);
+        SingleJpsi_genMatchIdx->push_back(
+            findCommonStoredGenMotherIdx(mu1Match.first, mu2Match.first, 443, genParticles));
 
         ++nSingleJpsiCand;
     }
@@ -2022,6 +2026,8 @@ void MultiLepPAT::storeSingleUpsCandidatesForMC(
         SingleUps_mu2_genMatchIdx->push_back(mu2Match.first);
         SingleUps_mu1_genMatchChi2->push_back(mu1Match.second);
         SingleUps_mu2_genMatchChi2->push_back(mu2Match.second);
+        SingleUps_genMatchIdx->push_back(
+            findCommonStoredGenMotherIdx(mu1Match.first, mu2Match.first, 553, genParticles));
 
         ++nSingleUpsCand;
     }
@@ -2149,6 +2155,10 @@ void MultiLepPAT::storeSinglePhiCandidatesForMC(
         SinglePhi_K2_genMatchSource->push_back(k2Diag.genMatchSource);
         SinglePhi_K1_genMatchChi2->push_back(k1Diag.genMatchChi2);
         SinglePhi_K2_genMatchChi2->push_back(k2Diag.genMatchChi2);
+        const int phiGenMatchIdx = (k1Diag.genMatchSource == 1 && k2Diag.genMatchSource == 1)
+            ? findCommonStoredGenMotherIdx(k1Diag.genMatchIdx, k2Diag.genMatchIdx, 333, genParticles)
+            : -1;
+        SinglePhi_genMatchIdx->push_back(phiGenMatchIdx);
         SinglePhi_commonAssocPVPass->push_back(phiDiag.commonAssocPVPass ? 1 : 0);
         SinglePhi_commonAssocPVIdx->push_back(phiDiag.commonAssocPVIdx);
         SinglePhi_trackPVPass->push_back(phiDiag.trackPVPass ? 1 : 0);
@@ -2207,6 +2217,53 @@ std::pair<int, float> MultiLepPAT::matchRecoMuonToStoredGenMuon(
     }
 
     return {bestStoredIdx, static_cast<float>(bestChi2)};
+}
+
+int MultiLepPAT::findCommonStoredGenMotherIdx(
+    int daughter1StoredIdx,
+    int daughter2StoredIdx,
+    int requiredMotherPdgId,
+    const edm::Handle<reco::GenParticleCollection>& genParticles) const
+{
+    if (daughter1StoredIdx < 0 || daughter2StoredIdx < 0 || !genParticles.isValid()) {
+        return -1;
+    }
+
+    const auto daughter1HandleIt = ntupleToHandleIndex_.find(daughter1StoredIdx);
+    const auto daughter2HandleIt = ntupleToHandleIndex_.find(daughter2StoredIdx);
+    if (daughter1HandleIt == ntupleToHandleIndex_.end() ||
+        daughter2HandleIt == ntupleToHandleIndex_.end() ||
+        daughter1HandleIt->second >= genParticles->size() ||
+        daughter2HandleIt->second >= genParticles->size()) {
+        return -1;
+    }
+
+    const auto& daughter1 = genParticles->at(daughter1HandleIt->second);
+    const auto& daughter2 = genParticles->at(daughter2HandleIt->second);
+    if (daughter1.numberOfMothers() == 0 || daughter2.numberOfMothers() == 0) {
+        return -1;
+    }
+
+    const reco::Candidate* mother1 = daughter1.mother(0);
+    const reco::Candidate* mother2 = daughter2.mother(0);
+    if (mother1 == nullptr || mother2 == nullptr || mother1 != mother2 ||
+        std::abs(mother1->pdgId()) != requiredMotherPdgId) {
+        return -1;
+    }
+
+    for (unsigned int genIdx = 0; genIdx < genParticles->size(); ++genIdx) {
+        if (&genParticles->at(genIdx) != mother1) {
+            continue;
+        }
+
+        const auto storedIt = handleToNtupleIndex_.find(genIdx);
+        if (storedIt == handleToNtupleIndex_.end()) {
+            return -1;
+        }
+        return storedIt->second;
+    }
+
+    return -1;
 }
 
 /*****************************************************************************
@@ -3172,6 +3229,7 @@ void MultiLepPAT::clearEventData()
     SingleJpsi_prefitEta->clear(); SingleJpsi_prefitPhi->clear();
     SingleJpsi_mu1_Idx->clear(); SingleJpsi_mu2_Idx->clear();
     SingleJpsi_mu1_charge->clear(); SingleJpsi_mu2_charge->clear();
+    SingleJpsi_genMatchIdx->clear();
     SingleJpsi_mu1_genMatchIdx->clear(); SingleJpsi_mu2_genMatchIdx->clear();
     SingleJpsi_mu1_genMatchChi2->clear(); SingleJpsi_mu2_genMatchChi2->clear();
 
@@ -3187,6 +3245,7 @@ void MultiLepPAT::clearEventData()
     SingleUps_prefitEta->clear(); SingleUps_prefitPhi->clear();
     SingleUps_mu1_Idx->clear(); SingleUps_mu2_Idx->clear();
     SingleUps_mu1_charge->clear(); SingleUps_mu2_charge->clear();
+    SingleUps_genMatchIdx->clear();
     SingleUps_mu1_genMatchIdx->clear(); SingleUps_mu2_genMatchIdx->clear();
     SingleUps_mu1_genMatchChi2->clear(); SingleUps_mu2_genMatchChi2->clear();
 
@@ -3212,6 +3271,7 @@ void MultiLepPAT::clearEventData()
     SinglePhi_K1_passTrackPV->clear(); SinglePhi_K2_passTrackPV->clear();
     SinglePhi_K1_dzPV->clear(); SinglePhi_K2_dzPV->clear();
     SinglePhi_K1_dxyPV->clear(); SinglePhi_K2_dxyPV->clear();
+    SinglePhi_genMatchIdx->clear();
     SinglePhi_K1_genMatchIdx->clear(); SinglePhi_K2_genMatchIdx->clear();
     SinglePhi_K1_genMatchSource->clear(); SinglePhi_K2_genMatchSource->clear();
     SinglePhi_K1_genMatchChi2->clear(); SinglePhi_K2_genMatchChi2->clear();
@@ -3230,6 +3290,7 @@ void MultiLepPAT::clearEventData()
 
     // Clear intermediate storage
     handleToNtupleIndex_.clear();
+    ntupleToHandleIndex_.clear();
     muPairCand_Onia1_.clear();
     muPairCand_Onia2_.clear();
     diOniaCands_.clear();
@@ -4207,6 +4268,7 @@ void MultiLepPAT::beginJob()
     X_One_Tree_->Branch("SingleJpsi_mu2_Idx", &SingleJpsi_mu2_Idx);
     X_One_Tree_->Branch("SingleJpsi_mu1_charge", &SingleJpsi_mu1_charge);
     X_One_Tree_->Branch("SingleJpsi_mu2_charge", &SingleJpsi_mu2_charge);
+    X_One_Tree_->Branch("SingleJpsi_genMatchIdx", &SingleJpsi_genMatchIdx);
     X_One_Tree_->Branch("SingleJpsi_mu1_genMatchIdx", &SingleJpsi_mu1_genMatchIdx);
     X_One_Tree_->Branch("SingleJpsi_mu2_genMatchIdx", &SingleJpsi_mu2_genMatchIdx);
     X_One_Tree_->Branch("SingleJpsi_mu1_genMatchChi2", &SingleJpsi_mu1_genMatchChi2);
@@ -4229,6 +4291,7 @@ void MultiLepPAT::beginJob()
     X_One_Tree_->Branch("SingleUps_mu2_Idx", &SingleUps_mu2_Idx);
     X_One_Tree_->Branch("SingleUps_mu1_charge", &SingleUps_mu1_charge);
     X_One_Tree_->Branch("SingleUps_mu2_charge", &SingleUps_mu2_charge);
+    X_One_Tree_->Branch("SingleUps_genMatchIdx", &SingleUps_genMatchIdx);
     X_One_Tree_->Branch("SingleUps_mu1_genMatchIdx", &SingleUps_mu1_genMatchIdx);
     X_One_Tree_->Branch("SingleUps_mu2_genMatchIdx", &SingleUps_mu2_genMatchIdx);
     X_One_Tree_->Branch("SingleUps_mu1_genMatchChi2", &SingleUps_mu1_genMatchChi2);
@@ -4275,6 +4338,7 @@ void MultiLepPAT::beginJob()
     X_One_Tree_->Branch("SinglePhi_K2_dxyPV", &SinglePhi_K2_dxyPV);
     X_One_Tree_->Branch("SinglePhi_K1_genMatchIdx", &SinglePhi_K1_genMatchIdx);
     X_One_Tree_->Branch("SinglePhi_K2_genMatchIdx", &SinglePhi_K2_genMatchIdx);
+    X_One_Tree_->Branch("SinglePhi_genMatchIdx", &SinglePhi_genMatchIdx);
     X_One_Tree_->Branch("SinglePhi_K1_genMatchSource", &SinglePhi_K1_genMatchSource);
     X_One_Tree_->Branch("SinglePhi_K2_genMatchSource", &SinglePhi_K2_genMatchSource);
     X_One_Tree_->Branch("SinglePhi_K1_genMatchChi2", &SinglePhi_K1_genMatchChi2);

--- a/src/MultiLepPAT.cc
+++ b/src/MultiLepPAT.cc
@@ -267,8 +267,14 @@ MultiLepPAT::MultiLepPAT(const edm::ParameterSet &iConfig)
       muonSelector_(muonSelectionStr_),
       trackSelectionStr_(iConfig.getUntrackedParameter<std::string>(
           "TrackSelection",
-          "pt > 2.0 && abs(eta) < 2.5 && numberOfHits > 4")),
+          "pt > 2.0 && abs(eta) < 2.5")),
       trackSelector_(trackSelectionStr_),
+      trackQualityStr_(iConfig.getUntrackedParameter<std::string>(
+          "TrackQuality",
+          "normalizedChi2 < 8 && numberOfValidHits > 4")),
+      trackQualitySelector_(trackQualityStr_),
+      requireRecoKaonTrackHighPurity_(
+          iConfig.getUntrackedParameter<bool>("RequireRecoKaonTrackHighPurity", true)),
       // Primary vertex cuts
       pvNdofMin_(iConfig.getUntrackedParameter<int>("PVNdofMin", 5)),
       pvMaxAbsZ_(iConfig.getUntrackedParameter<double>("PVMaxAbsZ", 24.0)),
@@ -1783,8 +1789,9 @@ void MultiLepPAT::pairTracks(
         if (static_cast<int>(iTrack1->fromPV()) < minTrackFromPV_) continue;
         // Use StringCutObjectSelector for track cuts
         if (!trackSelector_(*iTrack1)) continue;
-        if (iTrack1->bestTrack()->normalizedChi2() > 8 ||
-            !iTrack1->bestTrack()->quality(reco::Track::highPurity)) continue;
+        if (!trackQualitySelector_(*iTrack1->bestTrack()) ||
+            (requireRecoKaonTrackHighPurity_ &&
+             !iTrack1->bestTrack()->quality(reco::Track::highPurity))) continue;
 
         TransientTrack trackTT1(*(iTrack1->bestTrack()), &bField);
         transTrackPair.push_back(PhiFactory.particle(trackTT1, KMass, chi2, ndof, KMassSigma));
@@ -1795,8 +1802,9 @@ void MultiLepPAT::pairTracks(
             if (!iTrack2->hasTrackDetails() || iTrack2->charge() == 0) continue;
             if (static_cast<int>(iTrack2->fromPV()) < minTrackFromPV_) continue;
             if (!trackSelector_(*iTrack2)) continue;
-            if (iTrack2->bestTrack()->normalizedChi2() > 8 ||
-                !iTrack2->bestTrack()->quality(reco::Track::highPurity)) continue;
+            if (!trackQualitySelector_(*iTrack2->bestTrack()) ||
+                (requireRecoKaonTrackHighPurity_ &&
+                 !iTrack2->bestTrack()->quality(reco::Track::highPurity))) continue;
             if ((iTrack1->charge() + iTrack2->charge()) != 0) continue;
 
             TLorentzVector P4_Track1, P4_Track2, P4_Meson;
@@ -1866,13 +1874,7 @@ void MultiLepPAT::fillRecoKaonTrackBlock(
             const auto diagnostics = buildPhiKaonDiagnostics(cand, thePrimaryV_, genParticles);
             diagnosticsCache[nonMuonIdx] = diagnostics;
 
-            const bool hasGoodTrack = cand.hasTrackDetails() &&
-                                      cand.bestTrack() != nullptr &&
-                                      cand.bestTrack()->normalizedChi2() <= 8.0 &&
-                                      cand.bestTrack()->quality(reco::Track::highPurity);
-            const bool passesTrackSel = static_cast<int>(cand.fromPV()) >= minTrackFromPV_ &&
-                                        hasGoodTrack &&
-                                        trackSelector_(cand);
+            const bool passesTrackSel = trackSelector_(cand);
             if (diagnostics.genMatchIdx >= 0 && passesTrackSel) {
                 selectedNonMuonTrackIdx.insert(nonMuonIdx);
             }
@@ -4138,6 +4140,9 @@ void MultiLepPAT::beginJob()
     X_Config_Tree_->Branch("TrackLabel", &configTrackLabelTag_);
     X_Config_Tree_->Branch("MuonSelection", &muonSelectionStr_);
     X_Config_Tree_->Branch("TrackSelection", &trackSelectionStr_);
+    X_Config_Tree_->Branch("TrackQuality", &trackQualityStr_);
+    X_Config_Tree_->Branch("RequireRecoKaonTrackHighPurity", &requireRecoKaonTrackHighPurity_,
+                           "RequireRecoKaonTrackHighPurity/O");
     X_Config_Tree_->Branch("PVNdofMin", &pvNdofMin_, "PVNdofMin/I");
     X_Config_Tree_->Branch("PVMaxAbsZ", &pvMaxAbsZ_, "PVMaxAbsZ/D");
     X_Config_Tree_->Branch("PVMaxRho", &pvMaxRho_, "PVMaxRho/D");

--- a/src/MultiLepPAT.cc
+++ b/src/MultiLepPAT.cc
@@ -427,9 +427,9 @@ MultiLepPAT::MultiLepPAT(const edm::ParameterSet &iConfig)
       Jpsi_2_ndof(nullptr), Jpsi_2_VtxProb(nullptr),
       Phi_ctau(nullptr), Phi_ctauErr(nullptr), Phi_Chi2(nullptr),
       Phi_ndof(nullptr), Phi_VtxProb(nullptr),
-      Jpsi_1_phi(nullptr), Jpsi_1_eta(nullptr), Jpsi_1_pt(nullptr),
-      Jpsi_2_phi(nullptr), Jpsi_2_eta(nullptr), Jpsi_2_pt(nullptr),
-      Phi_phi(nullptr), Phi_eta(nullptr), Phi_pt(nullptr),
+      Jpsi_1_phi(nullptr), Jpsi_1_eta(nullptr), Jpsi_1_pt(nullptr), Jpsi_1_y(nullptr),
+      Jpsi_2_phi(nullptr), Jpsi_2_eta(nullptr), Jpsi_2_pt(nullptr), Jpsi_2_y(nullptr),
+      Phi_phi(nullptr), Phi_eta(nullptr), Phi_pt(nullptr), Phi_y(nullptr),
       Jpsi_1_px(nullptr), Jpsi_1_py(nullptr), Jpsi_1_pz(nullptr),
       Jpsi_2_px(nullptr), Jpsi_2_py(nullptr), Jpsi_2_pz(nullptr),
       Phi_px(nullptr), Phi_py(nullptr), Phi_pz(nullptr),
@@ -457,7 +457,7 @@ MultiLepPAT::MultiLepPAT(const edm::ParameterSet &iConfig)
       Pri_ctau(nullptr), Pri_ctauErr(nullptr), Pri_Chi2(nullptr),
       Pri_ndof(nullptr), Pri_VtxProb(nullptr),
       Pri_px(nullptr), Pri_py(nullptr), Pri_pz(nullptr),
-      Pri_phi(nullptr), Pri_eta(nullptr), Pri_pt(nullptr),
+      Pri_phi(nullptr), Pri_eta(nullptr), Pri_pt(nullptr), Pri_y(nullptr),
       Pri_pxErr(nullptr), Pri_pyErr(nullptr), Pri_pzErr(nullptr), Pri_ptErr(nullptr),
       Pri_fitValid(nullptr), Pri_fitPass(nullptr), Pri_assocPVPass(nullptr),
       Pri_assocPVIdx(nullptr), Pri_trackPVPass(nullptr), Pri_passAny(nullptr),
@@ -487,7 +487,7 @@ MultiLepPAT::MultiLepPAT(const edm::ParameterSet &iConfig)
       Ups_ctau(nullptr), Ups_ctauErr(nullptr), Ups_Chi2(nullptr),
       Ups_ndof(nullptr), Ups_VtxProb(nullptr),
       Ups_px(nullptr), Ups_py(nullptr), Ups_pz(nullptr),
-      Ups_phi(nullptr), Ups_eta(nullptr), Ups_pt(nullptr),
+      Ups_phi(nullptr), Ups_eta(nullptr), Ups_pt(nullptr), Ups_y(nullptr),
       Ups_pxErr(nullptr), Ups_pyErr(nullptr), Ups_pzErr(nullptr), Ups_ptErr(nullptr),
       // MC gen-level (new)
       MC_GenPart_pdgId(nullptr), MC_GenPart_status(nullptr), MC_GenPart_motherPdgId(nullptr),
@@ -1963,6 +1963,7 @@ void MultiLepPAT::storeSingleJpsiCandidatesForMC(
         SingleJpsi_phi->push_back(sentinel);
         SingleJpsi_eta->push_back(sentinel);
         SingleJpsi_pt->push_back(sentinel);
+        SingleJpsi_y->push_back(sentinel);
         SingleJpsi_pxErr->push_back(sentinel);
         SingleJpsi_pyErr->push_back(sentinel);
         SingleJpsi_pzErr->push_back(sentinel);
@@ -2011,6 +2012,7 @@ void MultiLepPAT::storeSingleJpsiCandidatesForMC(
                 SingleJpsi_Chi2, SingleJpsi_ndof, SingleJpsi_VtxProb,
                 SingleJpsi_px, SingleJpsi_py, SingleJpsi_pz,
                 SingleJpsi_phi, SingleJpsi_eta, SingleJpsi_pt,
+                SingleJpsi_y,
                 SingleJpsi_pxErr, SingleJpsi_pyErr, SingleJpsi_pzErr, SingleJpsi_ptErr);
         } else {
             pushSentinelResonance();
@@ -2062,6 +2064,7 @@ void MultiLepPAT::storeSingleUpsCandidatesForMC(
         SingleUps_phi->push_back(sentinel);
         SingleUps_eta->push_back(sentinel);
         SingleUps_pt->push_back(sentinel);
+        SingleUps_y->push_back(sentinel);
         SingleUps_pxErr->push_back(sentinel);
         SingleUps_pyErr->push_back(sentinel);
         SingleUps_pzErr->push_back(sentinel);
@@ -2110,6 +2113,7 @@ void MultiLepPAT::storeSingleUpsCandidatesForMC(
                 SingleUps_Chi2, SingleUps_ndof, SingleUps_VtxProb,
                 SingleUps_px, SingleUps_py, SingleUps_pz,
                 SingleUps_phi, SingleUps_eta, SingleUps_pt,
+                SingleUps_y,
                 SingleUps_pxErr, SingleUps_pyErr, SingleUps_pzErr, SingleUps_ptErr);
         } else {
             pushSentinelResonance();
@@ -2161,6 +2165,7 @@ void MultiLepPAT::storeSinglePhiCandidatesForMC(
         SinglePhi_phi->push_back(sentinel);
         SinglePhi_eta->push_back(sentinel);
         SinglePhi_pt->push_back(sentinel);
+        SinglePhi_y->push_back(sentinel);
         SinglePhi_pxErr->push_back(sentinel);
         SinglePhi_pyErr->push_back(sentinel);
         SinglePhi_pzErr->push_back(sentinel);
@@ -2213,6 +2218,7 @@ void MultiLepPAT::storeSinglePhiCandidatesForMC(
                 SinglePhi_Chi2, SinglePhi_ndof, SinglePhi_VtxProb,
                 SinglePhi_px, SinglePhi_py, SinglePhi_pz,
                 SinglePhi_phi, SinglePhi_eta, SinglePhi_pt,
+                SinglePhi_y,
                 SinglePhi_pxErr, SinglePhi_pyErr, SinglePhi_pzErr, SinglePhi_ptErr);
         } else {
             pushSentinelResonance();
@@ -2557,6 +2563,7 @@ void MultiLepPAT::combineCandidates(
                         Pri_mass, Pri_massErr, nullptr, Pri_ctau, Pri_ctauErr,
                         Pri_Chi2, Pri_ndof, Pri_VtxProb,
                         Pri_px, Pri_py, Pri_pz, Pri_phi, Pri_eta, Pri_pt,
+                        Pri_y,
                         Pri_pxErr, Pri_pyErr, Pri_pzErr, Pri_ptErr);
                 }
                 storePriDiagnostics(priDiagnostics);
@@ -2569,6 +2576,7 @@ void MultiLepPAT::combineCandidates(
                     Jpsi_1_Chi2, Jpsi_1_ndof, Jpsi_1_VtxProb,
                     Jpsi_1_px, Jpsi_1_py, Jpsi_1_pz,
                     Jpsi_1_phi, Jpsi_1_eta, Jpsi_1_pt,
+                    Jpsi_1_y,
                     Jpsi_1_pxErr, Jpsi_1_pyErr, Jpsi_1_pzErr, Jpsi_1_ptErr);
                 Jpsi_1_mu_1_Idx->push_back(diOnia.onia1.second[0]);
                 Jpsi_1_mu_2_Idx->push_back(diOnia.onia1.second[1]);
@@ -2581,6 +2589,7 @@ void MultiLepPAT::combineCandidates(
                         Jpsi_2_Chi2, Jpsi_2_ndof, Jpsi_2_VtxProb,
                         Jpsi_2_px, Jpsi_2_py, Jpsi_2_pz,
                         Jpsi_2_phi, Jpsi_2_eta, Jpsi_2_pt,
+                        Jpsi_2_y,
                         Jpsi_2_pxErr, Jpsi_2_pyErr, Jpsi_2_pzErr, Jpsi_2_ptErr);
                     Jpsi_2_mu_1_Idx->push_back(diOnia.onia2.second[0]);
                     Jpsi_2_mu_2_Idx->push_back(diOnia.onia2.second[1]);
@@ -2594,6 +2603,7 @@ void MultiLepPAT::combineCandidates(
                         Ups_Chi2, Ups_ndof, Ups_VtxProb,
                         Ups_px, Ups_py, Ups_pz,
                         Ups_phi, Ups_eta, Ups_pt,
+                        Ups_y,
                         Ups_pxErr, Ups_pyErr, Ups_pzErr, Ups_ptErr);
                     Ups_mu_1_Idx->push_back(diOnia.onia2.second[0]);
                     Ups_mu_2_Idx->push_back(diOnia.onia2.second[1]);
@@ -2613,6 +2623,7 @@ void MultiLepPAT::combineCandidates(
                     Phi_Chi2, Phi_ndof, Phi_VtxProb,
                     Phi_px, Phi_py, Phi_pz,
                     Phi_phi, Phi_eta, Phi_pt,
+                    Phi_y,
                     Phi_pxErr, Phi_pyErr, Phi_pzErr, Phi_ptErr);
 
                 const auto kaon1Diagnostics = buildPhiKaonDiagnostics(
@@ -2778,6 +2789,7 @@ void MultiLepPAT::combineCandidates(
                         Pri_mass, Pri_massErr, nullptr, Pri_ctau, Pri_ctauErr,
                         Pri_Chi2, Pri_ndof, Pri_VtxProb,
                         Pri_px, Pri_py, Pri_pz, Pri_phi, Pri_eta, Pri_pt,
+                        Pri_y,
                         Pri_pxErr, Pri_pyErr, Pri_pzErr, Pri_ptErr);
                 }
                 storePriDiagnostics(priDiagnostics);
@@ -2790,6 +2802,7 @@ void MultiLepPAT::combineCandidates(
                     Jpsi_1_Chi2, Jpsi_1_ndof, Jpsi_1_VtxProb,
                     Jpsi_1_px, Jpsi_1_py, Jpsi_1_pz,
                     Jpsi_1_phi, Jpsi_1_eta, Jpsi_1_pt,
+                    Jpsi_1_y,
                     Jpsi_1_pxErr, Jpsi_1_pyErr, Jpsi_1_pzErr, Jpsi_1_ptErr);
 
                 // Store J/psi 2
@@ -2799,6 +2812,7 @@ void MultiLepPAT::combineCandidates(
                     Jpsi_2_Chi2, Jpsi_2_ndof, Jpsi_2_VtxProb,
                     Jpsi_2_px, Jpsi_2_py, Jpsi_2_pz,
                     Jpsi_2_phi, Jpsi_2_eta, Jpsi_2_pt,
+                    Jpsi_2_y,
                     Jpsi_2_pxErr, Jpsi_2_pyErr, Jpsi_2_pzErr, Jpsi_2_ptErr);
 
                 // Store Upsilon
@@ -2808,6 +2822,7 @@ void MultiLepPAT::combineCandidates(
                     Ups_Chi2, Ups_ndof, Ups_VtxProb,
                     Ups_px, Ups_py, Ups_pz,
                     Ups_phi, Ups_eta, Ups_pt,
+                    Ups_y,
                     Ups_pxErr, Ups_pyErr, Ups_pzErr, Ups_ptErr);
 
                 // Store muon indices
@@ -2841,6 +2856,7 @@ void MultiLepPAT::storeSentinelPri()
     Pri_phi->push_back(sentinel);
     Pri_eta->push_back(sentinel);
     Pri_pt->push_back(sentinel);
+    Pri_y->push_back(sentinel);
     Pri_pxErr->push_back(sentinel);
     Pri_pyErr->push_back(sentinel);
     Pri_pzErr->push_back(sentinel);
@@ -3100,11 +3116,12 @@ void MultiLepPAT::storeResonanceBranches(
     vector<float>* br_Chi2, vector<float>* br_ndof, vector<float>* br_VtxProb,
     vector<float>* br_px, vector<float>* br_py, vector<float>* br_pz,
     vector<float>* br_phi, vector<float>* br_eta, vector<float>* br_pt,
+    vector<float>* br_y,
     vector<float>* br_pxErr, vector<float>* br_pyErr, vector<float>* br_pzErr,
     vector<float>* br_ptErr)
 {
-    double tmp_pt, tmp_eta, tmp_phi;
-    getDynamics(fitPart, tmp_pt, tmp_eta, tmp_phi);
+    double tmp_pt, tmp_eta, tmp_phi, tmp_y;
+    getDynamics(fitPart, tmp_pt, tmp_eta, tmp_phi, tmp_y);
 
     double tmp_pxErr, tmp_pyErr, tmp_pzErr, tmp_ptErr;
     getMomentumErrors(fitPart, tmp_pxErr, tmp_pyErr, tmp_pzErr, tmp_ptErr);
@@ -3130,6 +3147,7 @@ void MultiLepPAT::storeResonanceBranches(
     br_phi->push_back(tmp_phi);
     br_eta->push_back(tmp_eta);
     br_pt->push_back(tmp_pt);
+    br_y->push_back(tmp_y);
 
     if (br_pxErr) br_pxErr->push_back(tmp_pxErr);
     if (br_pyErr) br_pyErr->push_back(tmp_pyErr);
@@ -3276,7 +3294,7 @@ void MultiLepPAT::clearEventData()
     Pri_ctau->clear(); Pri_ctauErr->clear();
     Pri_Chi2->clear(); Pri_ndof->clear(); Pri_VtxProb->clear();
     Pri_px->clear(); Pri_py->clear(); Pri_pz->clear();
-    Pri_phi->clear(); Pri_eta->clear(); Pri_pt->clear();
+    Pri_phi->clear(); Pri_eta->clear(); Pri_pt->clear(); Pri_y->clear();
     Pri_pxErr->clear(); Pri_pyErr->clear(); Pri_pzErr->clear(); Pri_ptErr->clear();
     Pri_fitValid->clear(); Pri_fitPass->clear(); Pri_assocPVPass->clear();
     Pri_assocPVIdx->clear(); Pri_trackPVPass->clear(); Pri_passAny->clear();
@@ -3289,7 +3307,7 @@ void MultiLepPAT::clearEventData()
     Jpsi_1_ctau->clear(); Jpsi_1_ctauErr->clear();
     Jpsi_1_Chi2->clear(); Jpsi_1_ndof->clear(); Jpsi_1_VtxProb->clear();
     Jpsi_1_px->clear(); Jpsi_1_py->clear(); Jpsi_1_pz->clear();
-    Jpsi_1_phi->clear(); Jpsi_1_eta->clear(); Jpsi_1_pt->clear();
+    Jpsi_1_phi->clear(); Jpsi_1_eta->clear(); Jpsi_1_pt->clear(); Jpsi_1_y->clear();
     Jpsi_1_mu_1_Idx->clear(); Jpsi_1_mu_2_Idx->clear();
     Jpsi_1_pxErr->clear(); Jpsi_1_pyErr->clear(); Jpsi_1_pzErr->clear(); Jpsi_1_ptErr->clear();
 
@@ -3297,7 +3315,7 @@ void MultiLepPAT::clearEventData()
     Jpsi_2_ctau->clear(); Jpsi_2_ctauErr->clear();
     Jpsi_2_Chi2->clear(); Jpsi_2_ndof->clear(); Jpsi_2_VtxProb->clear();
     Jpsi_2_px->clear(); Jpsi_2_py->clear(); Jpsi_2_pz->clear();
-    Jpsi_2_phi->clear(); Jpsi_2_eta->clear(); Jpsi_2_pt->clear();
+    Jpsi_2_phi->clear(); Jpsi_2_eta->clear(); Jpsi_2_pt->clear(); Jpsi_2_y->clear();
     Jpsi_2_mu_1_Idx->clear(); Jpsi_2_mu_2_Idx->clear();
     Jpsi_2_pxErr->clear(); Jpsi_2_pyErr->clear(); Jpsi_2_pzErr->clear(); Jpsi_2_ptErr->clear();
 
@@ -3305,7 +3323,7 @@ void MultiLepPAT::clearEventData()
     Phi_ctau->clear(); Phi_ctauErr->clear();
     Phi_Chi2->clear(); Phi_ndof->clear(); Phi_VtxProb->clear();
     Phi_px->clear(); Phi_py->clear(); Phi_pz->clear();
-    Phi_phi->clear(); Phi_eta->clear(); Phi_pt->clear();
+    Phi_phi->clear(); Phi_eta->clear(); Phi_pt->clear(); Phi_y->clear();
     Phi_pxErr->clear(); Phi_pyErr->clear(); Phi_pzErr->clear(); Phi_ptErr->clear();
     Phi_fitPass->clear(); Phi_commonAssocPVPass->clear(); Phi_commonAssocPVIdx->clear();
     Phi_trackPVPass->clear(); Phi_vertexCriteriaPass->clear();
@@ -3338,7 +3356,7 @@ void MultiLepPAT::clearEventData()
     SingleJpsi_ctau->clear(); SingleJpsi_ctauErr->clear();
     SingleJpsi_Chi2->clear(); SingleJpsi_ndof->clear(); SingleJpsi_VtxProb->clear();
     SingleJpsi_px->clear(); SingleJpsi_py->clear(); SingleJpsi_pz->clear();
-    SingleJpsi_phi->clear(); SingleJpsi_eta->clear(); SingleJpsi_pt->clear();
+    SingleJpsi_phi->clear(); SingleJpsi_eta->clear(); SingleJpsi_pt->clear(); SingleJpsi_y->clear();
     SingleJpsi_pxErr->clear(); SingleJpsi_pyErr->clear(); SingleJpsi_pzErr->clear(); SingleJpsi_ptErr->clear();
     SingleJpsi_fitValid->clear(); SingleJpsi_fitPass->clear();
     SingleJpsi_prefitMass->clear(); SingleJpsi_prefitPt->clear();
@@ -3354,7 +3372,7 @@ void MultiLepPAT::clearEventData()
     SingleUps_ctau->clear(); SingleUps_ctauErr->clear();
     SingleUps_Chi2->clear(); SingleUps_ndof->clear(); SingleUps_VtxProb->clear();
     SingleUps_px->clear(); SingleUps_py->clear(); SingleUps_pz->clear();
-    SingleUps_phi->clear(); SingleUps_eta->clear(); SingleUps_pt->clear();
+    SingleUps_phi->clear(); SingleUps_eta->clear(); SingleUps_pt->clear(); SingleUps_y->clear();
     SingleUps_pxErr->clear(); SingleUps_pyErr->clear(); SingleUps_pzErr->clear(); SingleUps_ptErr->clear();
     SingleUps_fitValid->clear(); SingleUps_fitPass->clear();
     SingleUps_prefitMass->clear(); SingleUps_prefitPt->clear();
@@ -3370,7 +3388,7 @@ void MultiLepPAT::clearEventData()
     SinglePhi_ctau->clear(); SinglePhi_ctauErr->clear();
     SinglePhi_Chi2->clear(); SinglePhi_ndof->clear(); SinglePhi_VtxProb->clear();
     SinglePhi_px->clear(); SinglePhi_py->clear(); SinglePhi_pz->clear();
-    SinglePhi_phi->clear(); SinglePhi_eta->clear(); SinglePhi_pt->clear();
+    SinglePhi_phi->clear(); SinglePhi_eta->clear(); SinglePhi_pt->clear(); SinglePhi_y->clear();
     SinglePhi_pxErr->clear(); SinglePhi_pyErr->clear(); SinglePhi_pzErr->clear(); SinglePhi_ptErr->clear();
     SinglePhi_fitValid->clear(); SinglePhi_fitPass->clear();
     SinglePhi_prefitMass->clear(); SinglePhi_prefitPt->clear();
@@ -3416,7 +3434,7 @@ void MultiLepPAT::clearEventData()
     Ups_ctau->clear(); Ups_ctauErr->clear();
     Ups_Chi2->clear(); Ups_ndof->clear(); Ups_VtxProb->clear();
     Ups_px->clear(); Ups_py->clear(); Ups_pz->clear();
-    Ups_phi->clear(); Ups_eta->clear(); Ups_pt->clear();
+    Ups_phi->clear(); Ups_eta->clear(); Ups_pt->clear(); Ups_y->clear();
     Ups_pxErr->clear(); Ups_pyErr->clear(); Ups_pzErr->clear(); Ups_ptErr->clear();
 
     // Clear intermediate storage
@@ -3470,21 +3488,22 @@ void MultiLepPAT::getMomentumErrors(const RefCountedKinematicParticle& arg_Part,
  *****************************************************************************/
 
 void MultiLepPAT::getDynamics(double arg_mass, double arg_px, double arg_py, double arg_pz,
-                              double& res_pt, double& res_eta, double& res_phi) {
+                              double& res_pt, double& res_eta, double& res_phi, double& res_y) {
     TLorentzVector myParticle;
     myParticle.SetXYZM(arg_px, arg_py, arg_pz, arg_mass);
     res_pt  = myParticle.Pt();
     res_eta = myParticle.Eta();
     res_phi = myParticle.Phi();
+    res_y   = myParticle.Rapidity();
 }
 
 void MultiLepPAT::getDynamics(const RefCountedKinematicParticle& arg_Part,
-                              double& res_pt, double& res_eta, double& res_phi) {
+                              double& res_pt, double& res_eta, double& res_phi, double& res_y) {
     getDynamics(arg_Part->currentState().mass(),
                 arg_Part->currentState().kinematicParameters().momentum().x(),
                 arg_Part->currentState().kinematicParameters().momentum().y(),
                 arg_Part->currentState().kinematicParameters().momentum().z(),
-                res_pt, res_eta, res_phi);
+                res_pt, res_eta, res_phi, res_y);
 }
 
 void MultiLepPAT::tracksToMuonPair(
@@ -4321,6 +4340,7 @@ void MultiLepPAT::beginJob()
                           vector<float>*& Chi2, vector<float>*& ndof, vector<float>*& VtxProb,
                           vector<float>*& px, vector<float>*& py, vector<float>*& pz,
                           vector<float>*& phi, vector<float>*& eta, vector<float>*& pt,
+                          vector<float>*& y,
                           vector<float>*& pxErr, vector<float>*& pyErr, vector<float>*& pzErr,
                           vector<float>*& ptErr) {
         X_One_Tree_->Branch((prefix + "_mass").c_str(), &mass);
@@ -4337,6 +4357,7 @@ void MultiLepPAT::beginJob()
         X_One_Tree_->Branch((prefix + "_phi").c_str(), &phi);
         X_One_Tree_->Branch((prefix + "_eta").c_str(), &eta);
         X_One_Tree_->Branch((prefix + "_pt").c_str(), &pt);
+        X_One_Tree_->Branch((prefix + "_y").c_str(), &y);
         X_One_Tree_->Branch((prefix + "_pxErr").c_str(), &pxErr);
         X_One_Tree_->Branch((prefix + "_pyErr").c_str(), &pyErr);
         X_One_Tree_->Branch((prefix + "_pzErr").c_str(), &pzErr);
@@ -4357,6 +4378,7 @@ void MultiLepPAT::beginJob()
     branchReso("Jpsi_1", Jpsi_1_mass, Jpsi_1_massErr, Jpsi_1_massDiff,
                Jpsi_1_ctau, Jpsi_1_ctauErr, Jpsi_1_Chi2, Jpsi_1_ndof, Jpsi_1_VtxProb,
                Jpsi_1_px, Jpsi_1_py, Jpsi_1_pz, Jpsi_1_phi, Jpsi_1_eta, Jpsi_1_pt,
+               Jpsi_1_y,
                Jpsi_1_pxErr, Jpsi_1_pyErr, Jpsi_1_pzErr, Jpsi_1_ptErr);
     X_One_Tree_->Branch("Jpsi_1_mu_1_Idx", &Jpsi_1_mu_1_Idx);
     X_One_Tree_->Branch("Jpsi_1_mu_2_Idx", &Jpsi_1_mu_2_Idx);
@@ -4364,6 +4386,7 @@ void MultiLepPAT::beginJob()
     branchReso("Jpsi_2", Jpsi_2_mass, Jpsi_2_massErr, Jpsi_2_massDiff,
                Jpsi_2_ctau, Jpsi_2_ctauErr, Jpsi_2_Chi2, Jpsi_2_ndof, Jpsi_2_VtxProb,
                Jpsi_2_px, Jpsi_2_py, Jpsi_2_pz, Jpsi_2_phi, Jpsi_2_eta, Jpsi_2_pt,
+               Jpsi_2_y,
                Jpsi_2_pxErr, Jpsi_2_pyErr, Jpsi_2_pzErr, Jpsi_2_ptErr);
     X_One_Tree_->Branch("Jpsi_2_mu_1_Idx", &Jpsi_2_mu_1_Idx);
     X_One_Tree_->Branch("Jpsi_2_mu_2_Idx", &Jpsi_2_mu_2_Idx);
@@ -4371,6 +4394,7 @@ void MultiLepPAT::beginJob()
     branchReso("Phi", Phi_mass, Phi_massErr, Phi_massDiff,
                Phi_ctau, Phi_ctauErr, Phi_Chi2, Phi_ndof, Phi_VtxProb,
                Phi_px, Phi_py, Phi_pz, Phi_phi, Phi_eta, Phi_pt,
+               Phi_y,
                Phi_pxErr, Phi_pyErr, Phi_pzErr, Phi_ptErr);
     X_One_Tree_->Branch("Phi_fitPass", &Phi_fitPass);
     X_One_Tree_->Branch("Phi_commonAssocPVPass", &Phi_commonAssocPVPass);
@@ -4389,6 +4413,7 @@ void MultiLepPAT::beginJob()
                SingleJpsi_Chi2, SingleJpsi_ndof, SingleJpsi_VtxProb,
                SingleJpsi_px, SingleJpsi_py, SingleJpsi_pz,
                SingleJpsi_phi, SingleJpsi_eta, SingleJpsi_pt,
+               SingleJpsi_y,
                SingleJpsi_pxErr, SingleJpsi_pyErr, SingleJpsi_pzErr, SingleJpsi_ptErr);
     X_One_Tree_->Branch("SingleJpsi_fitValid", &SingleJpsi_fitValid);
     X_One_Tree_->Branch("SingleJpsi_fitPass", &SingleJpsi_fitPass);
@@ -4412,6 +4437,7 @@ void MultiLepPAT::beginJob()
                SingleUps_Chi2, SingleUps_ndof, SingleUps_VtxProb,
                SingleUps_px, SingleUps_py, SingleUps_pz,
                SingleUps_phi, SingleUps_eta, SingleUps_pt,
+               SingleUps_y,
                SingleUps_pxErr, SingleUps_pyErr, SingleUps_pzErr, SingleUps_ptErr);
     X_One_Tree_->Branch("SingleUps_fitValid", &SingleUps_fitValid);
     X_One_Tree_->Branch("SingleUps_fitPass", &SingleUps_fitPass);
@@ -4435,6 +4461,7 @@ void MultiLepPAT::beginJob()
                SinglePhi_Chi2, SinglePhi_ndof, SinglePhi_VtxProb,
                SinglePhi_px, SinglePhi_py, SinglePhi_pz,
                SinglePhi_phi, SinglePhi_eta, SinglePhi_pt,
+               SinglePhi_y,
                SinglePhi_pxErr, SinglePhi_pyErr, SinglePhi_pzErr, SinglePhi_ptErr);
     X_One_Tree_->Branch("SinglePhi_fitValid", &SinglePhi_fitValid);
     X_One_Tree_->Branch("SinglePhi_fitPass", &SinglePhi_fitPass);
@@ -4509,6 +4536,7 @@ void MultiLepPAT::beginJob()
     branchReso("Pri", Pri_mass, Pri_massErr, nullDiff,
                Pri_ctau, Pri_ctauErr, Pri_Chi2, Pri_ndof, Pri_VtxProb,
                Pri_px, Pri_py, Pri_pz, Pri_phi, Pri_eta, Pri_pt,
+               Pri_y,
                Pri_pxErr, Pri_pyErr, Pri_pzErr, Pri_ptErr);
     X_One_Tree_->Branch("Pri_fitValid", &Pri_fitValid);
     X_One_Tree_->Branch("Pri_fitPass", &Pri_fitPass);
@@ -4567,6 +4595,7 @@ void MultiLepPAT::beginJob()
     branchReso("Ups", Ups_mass, Ups_massErr, Ups_massDiff,
                Ups_ctau, Ups_ctauErr, Ups_Chi2, Ups_ndof, Ups_VtxProb,
                Ups_px, Ups_py, Ups_pz, Ups_phi, Ups_eta, Ups_pt,
+               Ups_y,
                Ups_pxErr, Ups_pyErr, Ups_pzErr, Ups_ptErr);
     X_One_Tree_->Branch("Ups_mu_1_Idx", &Ups_mu_1_Idx);
     X_One_Tree_->Branch("Ups_mu_2_Idx", &Ups_mu_2_Idx);

--- a/src/MultiLepPAT.cc
+++ b/src/MultiLepPAT.cc
@@ -743,6 +743,9 @@ void MultiLepPAT::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetu
         debugSummary.pairTracksMs = elapsedMs(stepStart);
     }
 
+    // Step 9a: Populate RecoKaonTrack cross-references from phi-candidate daughters.
+    fillRecoKaonTrackBlock(genParticles);
+
     if (keepSingles) {
         storeAllSingleObjectCandidatesForMC(theBeamSpotV_, genParticles);
         if (skipCompositeCandBuildingWhenKeepingSingles_) {
@@ -1827,7 +1830,7 @@ void MultiLepPAT::pairTracks(
 /*****************************************************************************
  * Store object-level candidates for MC efficiency studies
  *****************************************************************************/
-void MultiLepPAT::fillRecoKaonTrackBlockForMC(
+void MultiLepPAT::fillRecoKaonTrackBlock(
     const edm::Handle<reco::GenParticleCollection>& genParticles)
 {
     nRecoKaonTrack = 0;
@@ -1845,7 +1848,7 @@ void MultiLepPAT::fillRecoKaonTrackBlockForMC(
     RecoKaonTrack_genMatchChi2->clear();
     RecoKaonTrack_usedInSinglePhi->clear();
 
-    if (!doMC || !keepAllSingleObjectCandsInMC_ || nonMuonTrack_.empty()) {
+    if (nonMuonTrack_.empty()) {
         return;
     }
 
@@ -1853,20 +1856,22 @@ void MultiLepPAT::fillRecoKaonTrackBlockForMC(
     std::set<unsigned int> usedInSinglePhiSet;
     std::map<unsigned int, PhiKaonDiagnostics> diagnosticsCache;
 
-    for (unsigned int nonMuonIdx = 0; nonMuonIdx < nonMuonTrack_.size(); ++nonMuonIdx) {
-        const auto& cand = *nonMuonTrack_[nonMuonIdx];
-        const auto diagnostics = buildPhiKaonDiagnostics(cand, thePrimaryV_, genParticles);
-        diagnosticsCache[nonMuonIdx] = diagnostics;
+    if (doMC && keepAllSingleObjectCandsInMC_) {
+        for (unsigned int nonMuonIdx = 0; nonMuonIdx < nonMuonTrack_.size(); ++nonMuonIdx) {
+            const auto& cand = *nonMuonTrack_[nonMuonIdx];
+            const auto diagnostics = buildPhiKaonDiagnostics(cand, thePrimaryV_, genParticles);
+            diagnosticsCache[nonMuonIdx] = diagnostics;
 
-        const bool hasGoodTrack = cand.hasTrackDetails() &&
-                                  cand.bestTrack() != nullptr &&
-                                  cand.bestTrack()->normalizedChi2() <= 8.0 &&
-                                  cand.bestTrack()->quality(reco::Track::highPurity);
-        const bool passesTrackSel = static_cast<int>(cand.fromPV()) >= minTrackFromPV_ &&
-                                    hasGoodTrack &&
-                                    trackSelector_(cand);
-        if (diagnostics.genMatchIdx >= 0 && passesTrackSel) {
-            selectedNonMuonTrackIdx.insert(nonMuonIdx);
+            const bool hasGoodTrack = cand.hasTrackDetails() &&
+                                      cand.bestTrack() != nullptr &&
+                                      cand.bestTrack()->normalizedChi2() <= 8.0 &&
+                                      cand.bestTrack()->quality(reco::Track::highPurity);
+            const bool passesTrackSel = static_cast<int>(cand.fromPV()) >= minTrackFromPV_ &&
+                                        hasGoodTrack &&
+                                        trackSelector_(cand);
+            if (diagnostics.genMatchIdx >= 0 && passesTrackSel) {
+                selectedNonMuonTrackIdx.insert(nonMuonIdx);
+            }
         }
     }
 
@@ -1876,7 +1881,9 @@ void MultiLepPAT::fillRecoKaonTrackBlockForMC(
                 continue;
             }
             selectedNonMuonTrackIdx.insert(nonMuonIdx);
-            usedInSinglePhiSet.insert(nonMuonIdx);
+            if (doMC && keepAllSingleObjectCandsInMC_) {
+                usedInSinglePhiSet.insert(nonMuonIdx);
+            }
         }
     }
 
@@ -1920,8 +1927,6 @@ void MultiLepPAT::storeAllSingleObjectCandidatesForMC(
     if (!doMC || !keepAllSingleObjectCandsInMC_) {
         return;
     }
-
-    fillRecoKaonTrackBlockForMC(genParticles);
 
     storeSingleJpsiCandidatesForMC(beamSpotV, genParticles);
 

--- a/src/MultiLepPAT.cc
+++ b/src/MultiLepPAT.cc
@@ -33,6 +33,8 @@
 #include <string>
 #include <cmath>
 #include <limits>
+#include <map>
+#include <set>
 #include <unordered_set>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
@@ -438,6 +440,19 @@ MultiLepPAT::MultiLepPAT(const edm::ParameterSet &iConfig)
       Phi_fitPass(nullptr), Phi_commonAssocPVPass(nullptr), Phi_commonAssocPVIdx(nullptr),
       Phi_trackPVPass(nullptr), Phi_vertexCriteriaPass(nullptr),
       Phi_maxAbsDzPV(nullptr), Phi_maxAbsDxyPV(nullptr),
+      RecoKaonTrack_nonMuonTrackIdx(new vector<int>()),
+      RecoKaonTrack_pt(new vector<float>()), RecoKaonTrack_eta(new vector<float>()), RecoKaonTrack_phi(new vector<float>()),
+      RecoKaonTrack_px(new vector<float>()), RecoKaonTrack_py(new vector<float>()), RecoKaonTrack_pz(new vector<float>()),
+      RecoKaonTrack_charge(new vector<int>()),
+      RecoKaonTrack_fromPV(new vector<int>()), RecoKaonTrack_pvAssocQuality(new vector<int>()),
+      RecoKaonTrack_vertexId(new vector<int>()),
+      RecoKaonTrack_dzPV(new vector<float>()), RecoKaonTrack_dxyPV(new vector<float>()),
+      RecoKaonTrack_dzAssocPV(new vector<float>()), RecoKaonTrack_dxyAssocPV(new vector<float>()),
+      RecoKaonTrack_passDzPV(new vector<int>()), RecoKaonTrack_passDxyPV(new vector<int>()),
+      RecoKaonTrack_passTrackPV(new vector<int>()),
+      RecoKaonTrack_genMatchIdx(new vector<int>()), RecoKaonTrack_genMatchSource(new vector<int>()),
+      RecoKaonTrack_genMatchChi2(new vector<float>()),
+      RecoKaonTrack_usedInSinglePhi(new vector<int>()),
       Pri_mass(nullptr), Pri_massErr(nullptr),
       Pri_ctau(nullptr), Pri_ctauErr(nullptr), Pri_Chi2(nullptr),
       Pri_ndof(nullptr), Pri_VtxProb(nullptr),
@@ -1814,6 +1829,94 @@ void MultiLepPAT::pairTracks(
 /*****************************************************************************
  * Store object-level candidates for MC efficiency studies
  *****************************************************************************/
+void MultiLepPAT::fillRecoKaonTrackBlockForMC(
+    const edm::Handle<reco::GenParticleCollection>& genParticles)
+{
+    nRecoKaonTrack = 0;
+    nonMuonTrackIdxToRecoKaonTrackIdx_.clear();
+    RecoKaonTrack_nonMuonTrackIdx->clear();
+    RecoKaonTrack_pt->clear(); RecoKaonTrack_eta->clear(); RecoKaonTrack_phi->clear();
+    RecoKaonTrack_px->clear(); RecoKaonTrack_py->clear(); RecoKaonTrack_pz->clear();
+    RecoKaonTrack_charge->clear();
+    RecoKaonTrack_fromPV->clear(); RecoKaonTrack_pvAssocQuality->clear();
+    RecoKaonTrack_vertexId->clear();
+    RecoKaonTrack_dzPV->clear(); RecoKaonTrack_dxyPV->clear();
+    RecoKaonTrack_dzAssocPV->clear(); RecoKaonTrack_dxyAssocPV->clear();
+    RecoKaonTrack_passDzPV->clear(); RecoKaonTrack_passDxyPV->clear();
+    RecoKaonTrack_passTrackPV->clear();
+    RecoKaonTrack_genMatchIdx->clear(); RecoKaonTrack_genMatchSource->clear();
+    RecoKaonTrack_genMatchChi2->clear();
+    RecoKaonTrack_usedInSinglePhi->clear();
+
+    if (!doMC || !keepAllSingleObjectCandsInMC_ || nonMuonTrack_.empty()) {
+        return;
+    }
+
+    std::set<unsigned int> selectedNonMuonTrackIdx;
+    std::set<unsigned int> usedInSinglePhiSet;
+    std::map<unsigned int, PhiKaonDiagnostics> diagnosticsCache;
+
+    for (unsigned int nonMuonIdx = 0; nonMuonIdx < nonMuonTrack_.size(); ++nonMuonIdx) {
+        const auto& cand = *nonMuonTrack_[nonMuonIdx];
+        const auto diagnostics = buildPhiKaonDiagnostics(cand, thePrimaryV_, genParticles);
+        diagnosticsCache[nonMuonIdx] = diagnostics;
+
+        const bool hasGoodTrack = cand.hasTrackDetails() &&
+                                  cand.bestTrack() != nullptr &&
+                                  cand.bestTrack()->normalizedChi2() <= 8.0 &&
+                                  cand.bestTrack()->quality(reco::Track::highPurity);
+        const bool passesTrackSel = static_cast<int>(cand.fromPV()) >= minTrackFromPV_ &&
+                                    hasGoodTrack &&
+                                    trackSelector_(cand);
+        if (diagnostics.genMatchIdx >= 0 && passesTrackSel) {
+            selectedNonMuonTrackIdx.insert(nonMuonIdx);
+        }
+    }
+
+    for (const auto& pair : KPairCand_Meson_) {
+        for (const auto nonMuonIdx : pair.second) {
+            if (nonMuonIdx >= nonMuonTrack_.size()) {
+                continue;
+            }
+            selectedNonMuonTrackIdx.insert(nonMuonIdx);
+            usedInSinglePhiSet.insert(nonMuonIdx);
+        }
+    }
+
+    for (const auto nonMuonIdx : selectedNonMuonTrackIdx) {
+        const auto& cand = *nonMuonTrack_[nonMuonIdx];
+        const auto cacheIt = diagnosticsCache.find(nonMuonIdx);
+        const auto diagnostics = (cacheIt != diagnosticsCache.end())
+            ? cacheIt->second
+            : buildPhiKaonDiagnostics(cand, thePrimaryV_, genParticles);
+
+        nonMuonTrackIdxToRecoKaonTrackIdx_[nonMuonIdx] = nRecoKaonTrack;
+        RecoKaonTrack_nonMuonTrackIdx->push_back(static_cast<int>(nonMuonIdx));
+        RecoKaonTrack_pt->push_back(cand.pt());
+        RecoKaonTrack_eta->push_back(cand.eta());
+        RecoKaonTrack_phi->push_back(cand.phi());
+        RecoKaonTrack_px->push_back(cand.px());
+        RecoKaonTrack_py->push_back(cand.py());
+        RecoKaonTrack_pz->push_back(cand.pz());
+        RecoKaonTrack_charge->push_back(cand.charge());
+        RecoKaonTrack_fromPV->push_back(diagnostics.fromPV);
+        RecoKaonTrack_pvAssocQuality->push_back(diagnostics.pvAssocQuality);
+        RecoKaonTrack_vertexId->push_back(diagnostics.vertexId);
+        RecoKaonTrack_dzPV->push_back(diagnostics.dzPV);
+        RecoKaonTrack_dxyPV->push_back(diagnostics.dxyPV);
+        RecoKaonTrack_dzAssocPV->push_back(diagnostics.dzAssocPV);
+        RecoKaonTrack_dxyAssocPV->push_back(diagnostics.dxyAssocPV);
+        RecoKaonTrack_passDzPV->push_back(diagnostics.passDzPV ? 1 : 0);
+        RecoKaonTrack_passDxyPV->push_back(diagnostics.passDxyPV ? 1 : 0);
+        RecoKaonTrack_passTrackPV->push_back(diagnostics.passTrackPV ? 1 : 0);
+        RecoKaonTrack_genMatchIdx->push_back(diagnostics.genMatchIdx);
+        RecoKaonTrack_genMatchSource->push_back(diagnostics.genMatchSource);
+        RecoKaonTrack_genMatchChi2->push_back(diagnostics.genMatchChi2);
+        RecoKaonTrack_usedInSinglePhi->push_back(usedInSinglePhiSet.count(nonMuonIdx) ? 1 : 0);
+        ++nRecoKaonTrack;
+    }
+}
+
 void MultiLepPAT::storeAllSingleObjectCandidatesForMC(
     const reco::Vertex& beamSpotV,
     const edm::Handle<reco::GenParticleCollection>& genParticles)
@@ -1821,6 +1924,8 @@ void MultiLepPAT::storeAllSingleObjectCandidatesForMC(
     if (!doMC || !keepAllSingleObjectCandsInMC_) {
         return;
     }
+
+    fillRecoKaonTrackBlockForMC(genParticles);
 
     storeSingleJpsiCandidatesForMC(beamSpotV, genParticles);
 
@@ -3279,6 +3384,22 @@ void MultiLepPAT::clearEventData()
     SinglePhi_trackPVPass->clear(); SinglePhi_vertexCriteriaPass->clear();
     SinglePhi_maxAbsDzPV->clear(); SinglePhi_maxAbsDxyPV->clear();
 
+    nRecoKaonTrack = 0;
+    RecoKaonTrack_nonMuonTrackIdx->clear();
+    RecoKaonTrack_pt->clear(); RecoKaonTrack_eta->clear(); RecoKaonTrack_phi->clear();
+    RecoKaonTrack_px->clear(); RecoKaonTrack_py->clear(); RecoKaonTrack_pz->clear();
+    RecoKaonTrack_charge->clear();
+    RecoKaonTrack_fromPV->clear(); RecoKaonTrack_pvAssocQuality->clear();
+    RecoKaonTrack_vertexId->clear();
+    RecoKaonTrack_dzPV->clear(); RecoKaonTrack_dxyPV->clear();
+    RecoKaonTrack_dzAssocPV->clear(); RecoKaonTrack_dxyAssocPV->clear();
+    RecoKaonTrack_passDzPV->clear(); RecoKaonTrack_passDxyPV->clear();
+    RecoKaonTrack_passTrackPV->clear();
+    RecoKaonTrack_genMatchIdx->clear(); RecoKaonTrack_genMatchSource->clear();
+    RecoKaonTrack_genMatchChi2->clear();
+    RecoKaonTrack_usedInSinglePhi->clear();
+    nonMuonTrackIdxToRecoKaonTrackIdx_.clear();
+
     // Upsilon branches
     Ups_mu_1_Idx->clear(); Ups_mu_2_Idx->clear();
     Ups_mass->clear(); Ups_massErr->clear(); Ups_massDiff->clear();
@@ -3291,6 +3412,7 @@ void MultiLepPAT::clearEventData()
     // Clear intermediate storage
     handleToNtupleIndex_.clear();
     ntupleToHandleIndex_.clear();
+    nonMuonTrackIdxToRecoKaonTrackIdx_.clear();
     muPairCand_Onia1_.clear();
     muPairCand_Onia2_.clear();
     diOniaCands_.clear();
@@ -4349,6 +4471,30 @@ void MultiLepPAT::beginJob()
     X_One_Tree_->Branch("SinglePhi_vertexCriteriaPass", &SinglePhi_vertexCriteriaPass);
     X_One_Tree_->Branch("SinglePhi_maxAbsDzPV", &SinglePhi_maxAbsDzPV);
     X_One_Tree_->Branch("SinglePhi_maxAbsDxyPV", &SinglePhi_maxAbsDxyPV);
+
+    X_One_Tree_->Branch("nRecoKaonTrack", &nRecoKaonTrack, "nRecoKaonTrack/I");
+    X_One_Tree_->Branch("RecoKaonTrack_nonMuonTrackIdx", &RecoKaonTrack_nonMuonTrackIdx);
+    X_One_Tree_->Branch("RecoKaonTrack_pt", &RecoKaonTrack_pt);
+    X_One_Tree_->Branch("RecoKaonTrack_eta", &RecoKaonTrack_eta);
+    X_One_Tree_->Branch("RecoKaonTrack_phi", &RecoKaonTrack_phi);
+    X_One_Tree_->Branch("RecoKaonTrack_px", &RecoKaonTrack_px);
+    X_One_Tree_->Branch("RecoKaonTrack_py", &RecoKaonTrack_py);
+    X_One_Tree_->Branch("RecoKaonTrack_pz", &RecoKaonTrack_pz);
+    X_One_Tree_->Branch("RecoKaonTrack_charge", &RecoKaonTrack_charge);
+    X_One_Tree_->Branch("RecoKaonTrack_fromPV", &RecoKaonTrack_fromPV);
+    X_One_Tree_->Branch("RecoKaonTrack_pvAssocQuality", &RecoKaonTrack_pvAssocQuality);
+    X_One_Tree_->Branch("RecoKaonTrack_vertexId", &RecoKaonTrack_vertexId);
+    X_One_Tree_->Branch("RecoKaonTrack_dzPV", &RecoKaonTrack_dzPV);
+    X_One_Tree_->Branch("RecoKaonTrack_dxyPV", &RecoKaonTrack_dxyPV);
+    X_One_Tree_->Branch("RecoKaonTrack_dzAssocPV", &RecoKaonTrack_dzAssocPV);
+    X_One_Tree_->Branch("RecoKaonTrack_dxyAssocPV", &RecoKaonTrack_dxyAssocPV);
+    X_One_Tree_->Branch("RecoKaonTrack_passDzPV", &RecoKaonTrack_passDzPV);
+    X_One_Tree_->Branch("RecoKaonTrack_passDxyPV", &RecoKaonTrack_passDxyPV);
+    X_One_Tree_->Branch("RecoKaonTrack_passTrackPV", &RecoKaonTrack_passTrackPV);
+    X_One_Tree_->Branch("RecoKaonTrack_genMatchIdx", &RecoKaonTrack_genMatchIdx);
+    X_One_Tree_->Branch("RecoKaonTrack_genMatchSource", &RecoKaonTrack_genMatchSource);
+    X_One_Tree_->Branch("RecoKaonTrack_genMatchChi2", &RecoKaonTrack_genMatchChi2);
+    X_One_Tree_->Branch("RecoKaonTrack_usedInSinglePhi", &RecoKaonTrack_usedInSinglePhi);
 
     vector<float>* nullDiff = nullptr;
     branchReso("Pri", Pri_mass, Pri_massErr, nullDiff,

--- a/src/MultiLepPAT.cc
+++ b/src/MultiLepPAT.cc
@@ -418,6 +418,7 @@ MultiLepPAT::MultiLepPAT(const edm::ParameterSet &iConfig)
       Jpsi_1_mu_1_Idx(nullptr), Jpsi_1_mu_2_Idx(nullptr),
       Jpsi_2_mu_1_Idx(nullptr), Jpsi_2_mu_2_Idx(nullptr),
       Phi_K_1_Idx(nullptr), Phi_K_2_Idx(nullptr),
+      Phi_K_1_RecoKaonTrackIdx(new vector<int>()), Phi_K_2_RecoKaonTrackIdx(new vector<int>()),
       Jpsi_1_mass(nullptr), Jpsi_1_massErr(nullptr), Jpsi_1_massDiff(nullptr),
       Jpsi_2_mass(nullptr), Jpsi_2_massErr(nullptr), Jpsi_2_massDiff(nullptr),
       Phi_mass(nullptr), Phi_massErr(nullptr), Phi_massDiff(nullptr),
@@ -440,6 +441,7 @@ MultiLepPAT::MultiLepPAT(const edm::ParameterSet &iConfig)
       Phi_fitPass(nullptr), Phi_commonAssocPVPass(nullptr), Phi_commonAssocPVIdx(nullptr),
       Phi_trackPVPass(nullptr), Phi_vertexCriteriaPass(nullptr),
       Phi_maxAbsDzPV(nullptr), Phi_maxAbsDxyPV(nullptr),
+      SinglePhi_K1_RecoKaonTrackIdx(new vector<int>()), SinglePhi_K2_RecoKaonTrackIdx(new vector<int>()),
       RecoKaonTrack_nonMuonTrackIdx(new vector<int>()),
       RecoKaonTrack_pt(new vector<float>()), RecoKaonTrack_eta(new vector<float>()), RecoKaonTrack_phi(new vector<float>()),
       RecoKaonTrack_px(new vector<float>()), RecoKaonTrack_py(new vector<float>()), RecoKaonTrack_pz(new vector<float>()),
@@ -754,8 +756,7 @@ void MultiLepPAT::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetu
     const auto hasFullCandidateInputs = [&]() {
         switch (analysisChannel_) {
             case AnalysisChannel::JpsiJpsiPhi:
-                return muPairCand_Onia1_.size() >= 2 &&
-                       !diOniaCands_.empty() &&
+                return !diOniaCands_.empty() &&
                        !KPairCand_Meson_.empty();
             case AnalysisChannel::JpsiUpsPhi:
                 return !muPairCand_Onia1_.empty() &&
@@ -763,8 +764,7 @@ void MultiLepPAT::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetu
                        !diOniaCands_.empty() &&
                        !KPairCand_Meson_.empty();
             case AnalysisChannel::JpsiJpsiUps:
-                return muPairCand_Onia1_.size() >= 2 &&
-                       !muPairCand_Onia2_.empty() &&
+                return !muPairCand_Onia2_.empty() &&
                        !diOniaCands_.empty();
         }
         return false;
@@ -2225,6 +2225,12 @@ void MultiLepPAT::storeSinglePhiCandidatesForMC(
         SinglePhi_prefitPhi->push_back(p4Phi.Phi());
         SinglePhi_K1_nonMuonTrackIdx->push_back(static_cast<int>(iK1));
         SinglePhi_K2_nonMuonTrackIdx->push_back(static_cast<int>(iK2));
+        const auto singlePhiK1RecoIdx = nonMuonTrackIdxToRecoKaonTrackIdx_.find(iK1);
+        const auto singlePhiK2RecoIdx = nonMuonTrackIdxToRecoKaonTrackIdx_.find(iK2);
+        SinglePhi_K1_RecoKaonTrackIdx->push_back(
+            singlePhiK1RecoIdx != nonMuonTrackIdxToRecoKaonTrackIdx_.end() ? singlePhiK1RecoIdx->second : -1);
+        SinglePhi_K2_RecoKaonTrackIdx->push_back(
+            singlePhiK2RecoIdx != nonMuonTrackIdxToRecoKaonTrackIdx_.end() ? singlePhiK2RecoIdx->second : -1);
         SinglePhi_K1_charge->push_back(k1.charge());
         SinglePhi_K2_charge->push_back(k2.charge());
         SinglePhi_K1_pt->push_back(k1.pt());
@@ -2596,6 +2602,12 @@ void MultiLepPAT::combineCandidates(
 
                 Phi_K_1_Idx->push_back(KPair.second[0]);
                 Phi_K_2_Idx->push_back(KPair.second[1]);
+                const auto phiK1RecoIdx = nonMuonTrackIdxToRecoKaonTrackIdx_.find(KPair.second[0]);
+                const auto phiK2RecoIdx = nonMuonTrackIdxToRecoKaonTrackIdx_.find(KPair.second[1]);
+                Phi_K_1_RecoKaonTrackIdx->push_back(
+                    phiK1RecoIdx != nonMuonTrackIdxToRecoKaonTrackIdx_.end() ? phiK1RecoIdx->second : -1);
+                Phi_K_2_RecoKaonTrackIdx->push_back(
+                    phiK2RecoIdx != nonMuonTrackIdxToRecoKaonTrackIdx_.end() ? phiK2RecoIdx->second : -1);
 
                 // Store meson (Phi)
                 storeResonanceBranches(fitMeson, vtxMeson, massErrMeson, myPhiMass, bsV,
@@ -3302,7 +3314,8 @@ void MultiLepPAT::clearEventData()
     Phi_trackPVPass->clear(); Phi_vertexCriteriaPass->clear();
     Phi_maxAbsDzPV->clear(); Phi_maxAbsDxyPV->clear();
 
-    Phi_K_1_Idx->clear(); Phi_K_1_px->clear(); Phi_K_1_py->clear(); Phi_K_1_pz->clear();
+    Phi_K_1_Idx->clear(); Phi_K_1_RecoKaonTrackIdx->clear();
+    Phi_K_1_px->clear(); Phi_K_1_py->clear(); Phi_K_1_pz->clear();
     Phi_K_1_phi->clear(); Phi_K_1_eta->clear(); Phi_K_1_pt->clear();
     Phi_K_1_fromPV->clear(); Phi_K_1_pvAssocQuality->clear();
     Phi_K_1_hasAssocPV->clear(); Phi_K_1_passDzPV->clear();
@@ -3311,7 +3324,8 @@ void MultiLepPAT::clearEventData()
     Phi_K_1_dzPV->clear(); Phi_K_1_dxyPV->clear();
     Phi_K_1_dzAssocPV->clear(); Phi_K_1_dxyAssocPV->clear();
     Phi_K_1_genMatchIdx->clear(); Phi_K_1_genMatchSource->clear(); Phi_K_1_genMatchChi2->clear();
-    Phi_K_2_Idx->clear(); Phi_K_2_px->clear(); Phi_K_2_py->clear(); Phi_K_2_pz->clear();
+    Phi_K_2_Idx->clear(); Phi_K_2_RecoKaonTrackIdx->clear();
+    Phi_K_2_px->clear(); Phi_K_2_py->clear(); Phi_K_2_pz->clear();
     Phi_K_2_phi->clear(); Phi_K_2_eta->clear(); Phi_K_2_pt->clear();
     Phi_K_2_fromPV->clear(); Phi_K_2_pvAssocQuality->clear();
     Phi_K_2_hasAssocPV->clear(); Phi_K_2_passDzPV->clear();
@@ -3365,6 +3379,7 @@ void MultiLepPAT::clearEventData()
     SinglePhi_prefitMass->clear(); SinglePhi_prefitPt->clear();
     SinglePhi_prefitEta->clear(); SinglePhi_prefitPhi->clear();
     SinglePhi_K1_nonMuonTrackIdx->clear(); SinglePhi_K2_nonMuonTrackIdx->clear();
+    SinglePhi_K1_RecoKaonTrackIdx->clear(); SinglePhi_K2_RecoKaonTrackIdx->clear();
     SinglePhi_K1_charge->clear(); SinglePhi_K2_charge->clear();
     SinglePhi_K1_pt->clear(); SinglePhi_K1_eta->clear(); SinglePhi_K1_phi->clear();
     SinglePhi_K2_pt->clear(); SinglePhi_K2_eta->clear(); SinglePhi_K2_phi->clear();
@@ -4371,6 +4386,8 @@ void MultiLepPAT::beginJob()
     X_One_Tree_->Branch("Phi_maxAbsDxyPV", &Phi_maxAbsDxyPV);
     X_One_Tree_->Branch("Phi_K_1_Idx", &Phi_K_1_Idx);
     X_One_Tree_->Branch("Phi_K_2_Idx", &Phi_K_2_Idx);
+    X_One_Tree_->Branch("Phi_K_1_RecoKaonTrackIdx", &Phi_K_1_RecoKaonTrackIdx);
+    X_One_Tree_->Branch("Phi_K_2_RecoKaonTrackIdx", &Phi_K_2_RecoKaonTrackIdx);
 
 
     X_One_Tree_->Branch("nSingleJpsiCand", &nSingleJpsiCand, "nSingleJpsiCand/I");
@@ -4434,6 +4451,8 @@ void MultiLepPAT::beginJob()
     X_One_Tree_->Branch("SinglePhi_prefitPhi", &SinglePhi_prefitPhi);
     X_One_Tree_->Branch("SinglePhi_K1_nonMuonTrackIdx", &SinglePhi_K1_nonMuonTrackIdx);
     X_One_Tree_->Branch("SinglePhi_K2_nonMuonTrackIdx", &SinglePhi_K2_nonMuonTrackIdx);
+    X_One_Tree_->Branch("SinglePhi_K1_RecoKaonTrackIdx", &SinglePhi_K1_RecoKaonTrackIdx);
+    X_One_Tree_->Branch("SinglePhi_K2_RecoKaonTrackIdx", &SinglePhi_K2_RecoKaonTrackIdx);
     X_One_Tree_->Branch("SinglePhi_K1_charge", &SinglePhi_K1_charge);
     X_One_Tree_->Branch("SinglePhi_K2_charge", &SinglePhi_K2_charge);
     X_One_Tree_->Branch("SinglePhi_K1_pt", &SinglePhi_K1_pt);

--- a/src/MultiLepPAT.cc
+++ b/src/MultiLepPAT.cc
@@ -644,19 +644,37 @@ void MultiLepPAT::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetu
             nonMuonTrack_.push_back(iTrack);
         }
     }
-    debugSummary.nRecoMuons = thePATMuonHandle_.isValid() ? thePATMuonHandle_->size() : 0u;
-    debugSummary.nPackedTracks = theTrackHandle_.isValid() ? theTrackHandle_->size() : 0u;
+    const bool hasMuonHandle = thePATMuonHandle_.isValid();
+    const bool hasTrackHandle = theTrackHandle_.isValid();
+    const size_t nRecoMuons = hasMuonHandle ? thePATMuonHandle_->size() : 0u;
+    const bool keepSingles = doMC && keepAllSingleObjectCandsInMC_;
+    const bool needsTrackPairs = (analysisChannel_ == AnalysisChannel::JpsiJpsiPhi ||
+                                  analysisChannel_ == AnalysisChannel::JpsiUpsPhi);
+    const bool channelHasSingleUps = (analysisChannel_ == AnalysisChannel::JpsiUpsPhi ||
+                                      analysisChannel_ == AnalysisChannel::JpsiJpsiUps);
+
+    debugSummary.nRecoMuons = nRecoMuons;
+    debugSummary.nPackedTracks = hasTrackHandle ? theTrackHandle_->size() : 0u;
     debugSummary.nTrackPool = nonMuonTrack_.size();
 
     // Step 6: Fill the muon block for all available muons.
-    if (thePATMuonHandle_.isValid()) {
+    if (hasMuonHandle) {
         const auto stepStart = Clock::now();
         fillMuonBlock(iEvent, iSetup, thePrimaryV_);
         debugSummary.fillMuonBlockMs = elapsedMs(stepStart);
     }
 
+    const size_t nNonMuonTracks = nonMuonTrack_.size();
+    debugSummary.nTrackPool = nNonMuonTracks;
+
+    const bool canTrySingleJpsi = keepSingles && hasMuonHandle && nRecoMuons >= 2;
+    const bool canTrySingleUps = keepSingles && channelHasSingleUps && hasMuonHandle && nRecoMuons >= 2;
+    const bool canTrySinglePhi = keepSingles && needsTrackPairs && hasTrackHandle && nNonMuonTracks >= 2;
+    const bool canTryFullMuonSide = hasMuonHandle && nRecoMuons >= minMuonCount_;
+    const bool canTryFullPhiSide = !needsTrackPairs || (hasTrackHandle && nNonMuonTracks >= 2);
+
     // Step 7: MC matching of tracks
-    if (doMC && thePATMuonHandle_.isValid() && theTrackHandle_.isValid()) {
+    if (doMC && hasMuonHandle && hasTrackHandle) {
         const auto stepStart = Clock::now();
         doMCGenMatching(thePATMuonHandle_, theTrackHandle_);
         debugSummary.mcMatchMs = elapsedMs(stepStart);
@@ -696,32 +714,21 @@ void MultiLepPAT::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetu
         clearEventData();
     };
 
-    // Step 8: Pair muons
-    if (!thePATMuonHandle_.isValid() || thePATMuonHandle_->size() < minMuonCount_) {
-        finalizeCurrentEvent();
-        return;
+    // Step 8: Pair muons once when either single-object or full reconstruction needs them.
+    if (canTrySingleJpsi || canTrySingleUps || canTryFullMuonSide) {
+        const auto stepStart = Clock::now();
+        pairMuons(thePATMuonHandle_, bFieldHandle);
+        debugSummary.pairMuonsMs = elapsedMs(stepStart);
     }
 
-    {
-    const auto stepStart = Clock::now();
-    pairMuons(thePATMuonHandle_, bFieldHandle);
-    debugSummary.pairMuonsMs = elapsedMs(stepStart);
-    }
-
-    // Step 9: Pair tracks into meson candidates
-    bool needsTrackPairs = (analysisChannel_ == AnalysisChannel::JpsiJpsiPhi ||
-                            analysisChannel_ == AnalysisChannel::JpsiUpsPhi);
-    if (needsTrackPairs && !theTrackHandle_.isValid()) {
-        finalizeCurrentEvent();
-        return;
-    }
-    if (needsTrackPairs) {
+    // Step 9: Pair tracks once when either single-phi or full reconstruction needs them.
+    if (needsTrackPairs && (canTrySinglePhi || canTryFullPhiSide)) {
         const auto stepStart = Clock::now();
         pairTracks(nonMuonTrack_, bFieldHandle);
         debugSummary.pairTracksMs = elapsedMs(stepStart);
     }
 
-    if (doMC && keepAllSingleObjectCandsInMC_) {
+    if (keepSingles) {
         storeAllSingleObjectCandidatesForMC(theBeamSpotV_, genParticles);
         if (skipCompositeCandBuildingWhenKeepingSingles_) {
             finalizeCurrentEvent();
@@ -729,11 +736,35 @@ void MultiLepPAT::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetu
         }
     }
 
+    const auto hasFullCandidateInputs = [&]() {
+        switch (analysisChannel_) {
+            case AnalysisChannel::JpsiJpsiPhi:
+                return muPairCand_Onia1_.size() >= 2 &&
+                       !diOniaCands_.empty() &&
+                       !KPairCand_Meson_.empty();
+            case AnalysisChannel::JpsiUpsPhi:
+                return !muPairCand_Onia1_.empty() &&
+                       !muPairCand_Onia2_.empty() &&
+                       !diOniaCands_.empty() &&
+                       !KPairCand_Meson_.empty();
+            case AnalysisChannel::JpsiJpsiUps:
+                return muPairCand_Onia1_.size() >= 2 &&
+                       !muPairCand_Onia2_.empty() &&
+                       !diOniaCands_.empty();
+        }
+        return false;
+    };
+
+    if (!canTryFullMuonSide || !canTryFullPhiSide || !hasFullCandidateInputs()) {
+        finalizeCurrentEvent();
+        return;
+    }
+
     // Step 10: Combine candidates and fill branches
     {
-    const auto stepStart = Clock::now();
-    combineCandidates(theBeamSpotV_, genParticles);
-    debugSummary.combineCandidatesMs = elapsedMs(stepStart);
+        const auto stepStart = Clock::now();
+        combineCandidates(theBeamSpotV_, genParticles);
+        debugSummary.combineCandidatesMs = elapsedMs(stepStart);
     }
 
     finalizeCurrentEvent();
@@ -1791,6 +1822,11 @@ void MultiLepPAT::storeAllSingleObjectCandidatesForMC(
 
     storeSingleJpsiCandidatesForMC(beamSpotV, genParticles);
 
+    if (analysisChannel_ == AnalysisChannel::JpsiUpsPhi ||
+        analysisChannel_ == AnalysisChannel::JpsiJpsiUps) {
+        storeSingleUpsCandidatesForMC(beamSpotV, genParticles);
+    }
+
     if (analysisChannel_ == AnalysisChannel::JpsiJpsiPhi ||
         analysisChannel_ == AnalysisChannel::JpsiUpsPhi) {
         storeSinglePhiCandidatesForMC(beamSpotV, genParticles);
@@ -1883,14 +1919,111 @@ void MultiLepPAT::storeSingleJpsiCandidatesForMC(
         SingleJpsi_mu1_charge->push_back(mu1.charge());
         SingleJpsi_mu2_charge->push_back(mu2.charge());
 
-        const auto mu1Match = matchRecoMuonToStoredGenMuon(iMu1, genParticles, true);
-        const auto mu2Match = matchRecoMuonToStoredGenMuon(iMu2, genParticles, true);
+        const auto mu1Match = matchRecoMuonToStoredGenMuon(iMu1, genParticles, 443);
+        const auto mu2Match = matchRecoMuonToStoredGenMuon(iMu2, genParticles, 443);
         SingleJpsi_mu1_genMatchIdx->push_back(mu1Match.first);
         SingleJpsi_mu2_genMatchIdx->push_back(mu2Match.first);
         SingleJpsi_mu1_genMatchChi2->push_back(mu1Match.second);
         SingleJpsi_mu2_genMatchChi2->push_back(mu2Match.second);
 
         ++nSingleJpsiCand;
+    }
+}
+
+void MultiLepPAT::storeSingleUpsCandidatesForMC(
+    const reco::Vertex& beamSpotV,
+    const edm::Handle<reco::GenParticleCollection>& genParticles)
+{
+    nSingleUpsCand = 0;
+
+    auto pushSentinelResonance = [&]() {
+        const float sentinel = -999999.f;
+        SingleUps_mass->push_back(sentinel);
+        SingleUps_massErr->push_back(sentinel);
+        SingleUps_massDiff->push_back(sentinel);
+        SingleUps_ctau->push_back(sentinel);
+        SingleUps_ctauErr->push_back(sentinel);
+        SingleUps_Chi2->push_back(sentinel);
+        SingleUps_ndof->push_back(sentinel);
+        SingleUps_VtxProb->push_back(sentinel);
+        SingleUps_px->push_back(sentinel);
+        SingleUps_py->push_back(sentinel);
+        SingleUps_pz->push_back(sentinel);
+        SingleUps_phi->push_back(sentinel);
+        SingleUps_eta->push_back(sentinel);
+        SingleUps_pt->push_back(sentinel);
+        SingleUps_pxErr->push_back(sentinel);
+        SingleUps_pyErr->push_back(sentinel);
+        SingleUps_pzErr->push_back(sentinel);
+        SingleUps_ptErr->push_back(sentinel);
+    };
+
+    reco::Vertex bsV(beamSpotV);
+
+    for (const auto& pair : muPairCand_Onia2_) {
+        const auto& particles = pair.first;
+        const auto& muIdx = pair.second;
+        if (muIdx.size() != 2 || !thePATMuonHandle_.isValid()) {
+            continue;
+        }
+
+        const unsigned int iMu1 = muIdx[0];
+        const unsigned int iMu2 = muIdx[1];
+        if (iMu1 >= thePATMuonHandle_->size() || iMu2 >= thePATMuonHandle_->size()) {
+            continue;
+        }
+
+        const auto& mu1 = thePATMuonHandle_->at(iMu1);
+        const auto& mu2 = thePATMuonHandle_->at(iMu2);
+        const auto prefitP4 = mu1.p4() + mu2.p4();
+
+        RefCountedKinematicTree vtxFitTree;
+        RefCountedKinematicParticle fitUps;
+        RefCountedKinematicVertex vtxUps;
+        double massErr = -1.0;
+        bool fitValid = particlesToVtx(vtxFitTree, particles, "SingleUps", UpsDecayVtxProbCut_);
+        bool fitPass = false;
+
+        if (fitValid) {
+            fitValid = extractFitRes(vtxFitTree, fitUps, vtxUps, massErr);
+        }
+
+        if (fitValid && massErr >= 0.0) {
+            const double vtxProb = ChiSquaredProbability(
+                static_cast<double>(vtxUps->chiSquared()),
+                static_cast<double>(vtxUps->degreesOfFreedom()));
+            fitPass = vtxProb >= UpsDecayVtxProbCut_;
+            storeResonanceBranches(
+                fitUps, vtxUps, massErr, myUpsMass, bsV,
+                SingleUps_mass, SingleUps_massErr, SingleUps_massDiff,
+                SingleUps_ctau, SingleUps_ctauErr,
+                SingleUps_Chi2, SingleUps_ndof, SingleUps_VtxProb,
+                SingleUps_px, SingleUps_py, SingleUps_pz,
+                SingleUps_phi, SingleUps_eta, SingleUps_pt,
+                SingleUps_pxErr, SingleUps_pyErr, SingleUps_pzErr, SingleUps_ptErr);
+        } else {
+            pushSentinelResonance();
+        }
+
+        SingleUps_fitValid->push_back(fitValid ? 1 : 0);
+        SingleUps_fitPass->push_back(fitPass ? 1 : 0);
+        SingleUps_prefitMass->push_back(prefitP4.mass());
+        SingleUps_prefitPt->push_back(prefitP4.pt());
+        SingleUps_prefitEta->push_back(prefitP4.eta());
+        SingleUps_prefitPhi->push_back(prefitP4.phi());
+        SingleUps_mu1_Idx->push_back(static_cast<int>(iMu1));
+        SingleUps_mu2_Idx->push_back(static_cast<int>(iMu2));
+        SingleUps_mu1_charge->push_back(mu1.charge());
+        SingleUps_mu2_charge->push_back(mu2.charge());
+
+        const auto mu1Match = matchRecoMuonToStoredGenMuon(iMu1, genParticles, 553);
+        const auto mu2Match = matchRecoMuonToStoredGenMuon(iMu2, genParticles, 553);
+        SingleUps_mu1_genMatchIdx->push_back(mu1Match.first);
+        SingleUps_mu2_genMatchIdx->push_back(mu2Match.first);
+        SingleUps_mu1_genMatchChi2->push_back(mu1Match.second);
+        SingleUps_mu2_genMatchChi2->push_back(mu2Match.second);
+
+        ++nSingleUpsCand;
     }
 }
 
@@ -2030,7 +2163,7 @@ void MultiLepPAT::storeSinglePhiCandidatesForMC(
 std::pair<int, float> MultiLepPAT::matchRecoMuonToStoredGenMuon(
     unsigned int muIdx,
     const edm::Handle<reco::GenParticleCollection>& genParticles,
-    bool requireJpsiMother) const
+    int requiredMotherPdgId) const
 {
     if (!thePATMuonHandle_.isValid() || muIdx >= thePATMuonHandle_->size() ||
         !genParticles.isValid()) {
@@ -2049,9 +2182,9 @@ std::pair<int, float> MultiLepPAT::matchRecoMuonToStoredGenMuon(
         if (gen.charge() != 0 && gen.charge() != mu.charge()) {
             continue;
         }
-        if (requireJpsiMother &&
+        if (requiredMotherPdgId != 0 &&
             (gen.numberOfMothers() == 0 || gen.mother(0) == nullptr ||
-             std::abs(gen.mother(0)->pdgId()) != 443)) {
+             std::abs(gen.mother(0)->pdgId()) != requiredMotherPdgId)) {
             continue;
         }
 
@@ -3042,6 +3175,21 @@ void MultiLepPAT::clearEventData()
     SingleJpsi_mu1_genMatchIdx->clear(); SingleJpsi_mu2_genMatchIdx->clear();
     SingleJpsi_mu1_genMatchChi2->clear(); SingleJpsi_mu2_genMatchChi2->clear();
 
+    nSingleUpsCand = 0;
+    SingleUps_mass->clear(); SingleUps_massErr->clear(); SingleUps_massDiff->clear();
+    SingleUps_ctau->clear(); SingleUps_ctauErr->clear();
+    SingleUps_Chi2->clear(); SingleUps_ndof->clear(); SingleUps_VtxProb->clear();
+    SingleUps_px->clear(); SingleUps_py->clear(); SingleUps_pz->clear();
+    SingleUps_phi->clear(); SingleUps_eta->clear(); SingleUps_pt->clear();
+    SingleUps_pxErr->clear(); SingleUps_pyErr->clear(); SingleUps_pzErr->clear(); SingleUps_ptErr->clear();
+    SingleUps_fitValid->clear(); SingleUps_fitPass->clear();
+    SingleUps_prefitMass->clear(); SingleUps_prefitPt->clear();
+    SingleUps_prefitEta->clear(); SingleUps_prefitPhi->clear();
+    SingleUps_mu1_Idx->clear(); SingleUps_mu2_Idx->clear();
+    SingleUps_mu1_charge->clear(); SingleUps_mu2_charge->clear();
+    SingleUps_mu1_genMatchIdx->clear(); SingleUps_mu2_genMatchIdx->clear();
+    SingleUps_mu1_genMatchChi2->clear(); SingleUps_mu2_genMatchChi2->clear();
+
     nSinglePhiCand = 0;
     SinglePhi_mass->clear(); SinglePhi_massErr->clear(); SinglePhi_massDiff->clear();
     SinglePhi_ctau->clear(); SinglePhi_ctauErr->clear();
@@ -4010,6 +4158,7 @@ void MultiLepPAT::beginJob()
     Phi_massDiff    = new vector<float>();
     Ups_massDiff    = new vector<float>();
     SingleJpsi_massDiff = new vector<float>();
+    SingleUps_massDiff = new vector<float>();
     SinglePhi_massDiff = new vector<float>();
 
     branchReso("Jpsi_1", Jpsi_1_mass, Jpsi_1_massErr, Jpsi_1_massDiff,
@@ -4062,6 +4211,28 @@ void MultiLepPAT::beginJob()
     X_One_Tree_->Branch("SingleJpsi_mu2_genMatchIdx", &SingleJpsi_mu2_genMatchIdx);
     X_One_Tree_->Branch("SingleJpsi_mu1_genMatchChi2", &SingleJpsi_mu1_genMatchChi2);
     X_One_Tree_->Branch("SingleJpsi_mu2_genMatchChi2", &SingleJpsi_mu2_genMatchChi2);
+
+    X_One_Tree_->Branch("nSingleUpsCand", &nSingleUpsCand, "nSingleUpsCand/I");
+    branchReso("SingleUps", SingleUps_mass, SingleUps_massErr, SingleUps_massDiff,
+               SingleUps_ctau, SingleUps_ctauErr,
+               SingleUps_Chi2, SingleUps_ndof, SingleUps_VtxProb,
+               SingleUps_px, SingleUps_py, SingleUps_pz,
+               SingleUps_phi, SingleUps_eta, SingleUps_pt,
+               SingleUps_pxErr, SingleUps_pyErr, SingleUps_pzErr, SingleUps_ptErr);
+    X_One_Tree_->Branch("SingleUps_fitValid", &SingleUps_fitValid);
+    X_One_Tree_->Branch("SingleUps_fitPass", &SingleUps_fitPass);
+    X_One_Tree_->Branch("SingleUps_prefitMass", &SingleUps_prefitMass);
+    X_One_Tree_->Branch("SingleUps_prefitPt", &SingleUps_prefitPt);
+    X_One_Tree_->Branch("SingleUps_prefitEta", &SingleUps_prefitEta);
+    X_One_Tree_->Branch("SingleUps_prefitPhi", &SingleUps_prefitPhi);
+    X_One_Tree_->Branch("SingleUps_mu1_Idx", &SingleUps_mu1_Idx);
+    X_One_Tree_->Branch("SingleUps_mu2_Idx", &SingleUps_mu2_Idx);
+    X_One_Tree_->Branch("SingleUps_mu1_charge", &SingleUps_mu1_charge);
+    X_One_Tree_->Branch("SingleUps_mu2_charge", &SingleUps_mu2_charge);
+    X_One_Tree_->Branch("SingleUps_mu1_genMatchIdx", &SingleUps_mu1_genMatchIdx);
+    X_One_Tree_->Branch("SingleUps_mu2_genMatchIdx", &SingleUps_mu2_genMatchIdx);
+    X_One_Tree_->Branch("SingleUps_mu1_genMatchChi2", &SingleUps_mu1_genMatchChi2);
+    X_One_Tree_->Branch("SingleUps_mu2_genMatchChi2", &SingleUps_mu2_genMatchChi2);
 
     X_One_Tree_->Branch("nSinglePhiCand", &nSinglePhiCand, "nSinglePhiCand/I");
     branchReso("SinglePhi", SinglePhi_mass, SinglePhi_massErr, SinglePhi_massDiff,

--- a/src/MultiLepPAT.cc
+++ b/src/MultiLepPAT.cc
@@ -417,7 +417,6 @@ MultiLepPAT::MultiLepPAT(const edm::ParameterSet &iConfig)
       muMatch_bestDz(nullptr), muMatch_methodUsed(nullptr),
       Jpsi_1_mu_1_Idx(nullptr), Jpsi_1_mu_2_Idx(nullptr),
       Jpsi_2_mu_1_Idx(nullptr), Jpsi_2_mu_2_Idx(nullptr),
-      Phi_K_1_Idx(nullptr), Phi_K_2_Idx(nullptr),
       Phi_K_1_RecoKaonTrackIdx(new vector<int>()), Phi_K_2_RecoKaonTrackIdx(new vector<int>()),
       Jpsi_1_mass(nullptr), Jpsi_1_massErr(nullptr), Jpsi_1_massDiff(nullptr),
       Jpsi_2_mass(nullptr), Jpsi_2_massErr(nullptr), Jpsi_2_massDiff(nullptr),
@@ -442,7 +441,6 @@ MultiLepPAT::MultiLepPAT(const edm::ParameterSet &iConfig)
       Phi_trackPVPass(nullptr), Phi_vertexCriteriaPass(nullptr),
       Phi_maxAbsDzPV(nullptr), Phi_maxAbsDxyPV(nullptr),
       SinglePhi_K1_RecoKaonTrackIdx(new vector<int>()), SinglePhi_K2_RecoKaonTrackIdx(new vector<int>()),
-      RecoKaonTrack_nonMuonTrackIdx(new vector<int>()),
       RecoKaonTrack_pt(new vector<float>()), RecoKaonTrack_eta(new vector<float>()), RecoKaonTrack_phi(new vector<float>()),
       RecoKaonTrack_px(new vector<float>()), RecoKaonTrack_py(new vector<float>()), RecoKaonTrack_pz(new vector<float>()),
       RecoKaonTrack_charge(new vector<int>()),
@@ -1834,7 +1832,6 @@ void MultiLepPAT::fillRecoKaonTrackBlockForMC(
 {
     nRecoKaonTrack = 0;
     nonMuonTrackIdxToRecoKaonTrackIdx_.clear();
-    RecoKaonTrack_nonMuonTrackIdx->clear();
     RecoKaonTrack_pt->clear(); RecoKaonTrack_eta->clear(); RecoKaonTrack_phi->clear();
     RecoKaonTrack_px->clear(); RecoKaonTrack_py->clear(); RecoKaonTrack_pz->clear();
     RecoKaonTrack_charge->clear();
@@ -1891,7 +1888,6 @@ void MultiLepPAT::fillRecoKaonTrackBlockForMC(
             : buildPhiKaonDiagnostics(cand, thePrimaryV_, genParticles);
 
         nonMuonTrackIdxToRecoKaonTrackIdx_[nonMuonIdx] = nRecoKaonTrack;
-        RecoKaonTrack_nonMuonTrackIdx->push_back(static_cast<int>(nonMuonIdx));
         RecoKaonTrack_pt->push_back(cand.pt());
         RecoKaonTrack_eta->push_back(cand.eta());
         RecoKaonTrack_phi->push_back(cand.phi());
@@ -2223,8 +2219,6 @@ void MultiLepPAT::storeSinglePhiCandidatesForMC(
         SinglePhi_prefitPt->push_back(p4Phi.Pt());
         SinglePhi_prefitEta->push_back(p4Phi.Eta());
         SinglePhi_prefitPhi->push_back(p4Phi.Phi());
-        SinglePhi_K1_nonMuonTrackIdx->push_back(static_cast<int>(iK1));
-        SinglePhi_K2_nonMuonTrackIdx->push_back(static_cast<int>(iK2));
         const auto singlePhiK1RecoIdx = nonMuonTrackIdxToRecoKaonTrackIdx_.find(iK1);
         const auto singlePhiK2RecoIdx = nonMuonTrackIdxToRecoKaonTrackIdx_.find(iK2);
         SinglePhi_K1_RecoKaonTrackIdx->push_back(
@@ -2600,8 +2594,6 @@ void MultiLepPAT::combineCandidates(
                     Ups_mu_2_Idx->push_back(diOnia.onia2.second[1]);
                 }
 
-                Phi_K_1_Idx->push_back(KPair.second[0]);
-                Phi_K_2_Idx->push_back(KPair.second[1]);
                 const auto phiK1RecoIdx = nonMuonTrackIdxToRecoKaonTrackIdx_.find(KPair.second[0]);
                 const auto phiK2RecoIdx = nonMuonTrackIdxToRecoKaonTrackIdx_.find(KPair.second[1]);
                 Phi_K_1_RecoKaonTrackIdx->push_back(
@@ -3314,7 +3306,7 @@ void MultiLepPAT::clearEventData()
     Phi_trackPVPass->clear(); Phi_vertexCriteriaPass->clear();
     Phi_maxAbsDzPV->clear(); Phi_maxAbsDxyPV->clear();
 
-    Phi_K_1_Idx->clear(); Phi_K_1_RecoKaonTrackIdx->clear();
+    Phi_K_1_RecoKaonTrackIdx->clear();
     Phi_K_1_px->clear(); Phi_K_1_py->clear(); Phi_K_1_pz->clear();
     Phi_K_1_phi->clear(); Phi_K_1_eta->clear(); Phi_K_1_pt->clear();
     Phi_K_1_fromPV->clear(); Phi_K_1_pvAssocQuality->clear();
@@ -3324,7 +3316,7 @@ void MultiLepPAT::clearEventData()
     Phi_K_1_dzPV->clear(); Phi_K_1_dxyPV->clear();
     Phi_K_1_dzAssocPV->clear(); Phi_K_1_dxyAssocPV->clear();
     Phi_K_1_genMatchIdx->clear(); Phi_K_1_genMatchSource->clear(); Phi_K_1_genMatchChi2->clear();
-    Phi_K_2_Idx->clear(); Phi_K_2_RecoKaonTrackIdx->clear();
+    Phi_K_2_RecoKaonTrackIdx->clear();
     Phi_K_2_px->clear(); Phi_K_2_py->clear(); Phi_K_2_pz->clear();
     Phi_K_2_phi->clear(); Phi_K_2_eta->clear(); Phi_K_2_pt->clear();
     Phi_K_2_fromPV->clear(); Phi_K_2_pvAssocQuality->clear();
@@ -3378,7 +3370,6 @@ void MultiLepPAT::clearEventData()
     SinglePhi_fitValid->clear(); SinglePhi_fitPass->clear();
     SinglePhi_prefitMass->clear(); SinglePhi_prefitPt->clear();
     SinglePhi_prefitEta->clear(); SinglePhi_prefitPhi->clear();
-    SinglePhi_K1_nonMuonTrackIdx->clear(); SinglePhi_K2_nonMuonTrackIdx->clear();
     SinglePhi_K1_RecoKaonTrackIdx->clear(); SinglePhi_K2_RecoKaonTrackIdx->clear();
     SinglePhi_K1_charge->clear(); SinglePhi_K2_charge->clear();
     SinglePhi_K1_pt->clear(); SinglePhi_K1_eta->clear(); SinglePhi_K1_phi->clear();
@@ -3400,7 +3391,6 @@ void MultiLepPAT::clearEventData()
     SinglePhi_maxAbsDzPV->clear(); SinglePhi_maxAbsDxyPV->clear();
 
     nRecoKaonTrack = 0;
-    RecoKaonTrack_nonMuonTrackIdx->clear();
     RecoKaonTrack_pt->clear(); RecoKaonTrack_eta->clear(); RecoKaonTrack_phi->clear();
     RecoKaonTrack_px->clear(); RecoKaonTrack_py->clear(); RecoKaonTrack_pz->clear();
     RecoKaonTrack_charge->clear();
@@ -4384,8 +4374,6 @@ void MultiLepPAT::beginJob()
     X_One_Tree_->Branch("Phi_vertexCriteriaPass", &Phi_vertexCriteriaPass);
     X_One_Tree_->Branch("Phi_maxAbsDzPV", &Phi_maxAbsDzPV);
     X_One_Tree_->Branch("Phi_maxAbsDxyPV", &Phi_maxAbsDxyPV);
-    X_One_Tree_->Branch("Phi_K_1_Idx", &Phi_K_1_Idx);
-    X_One_Tree_->Branch("Phi_K_2_Idx", &Phi_K_2_Idx);
     X_One_Tree_->Branch("Phi_K_1_RecoKaonTrackIdx", &Phi_K_1_RecoKaonTrackIdx);
     X_One_Tree_->Branch("Phi_K_2_RecoKaonTrackIdx", &Phi_K_2_RecoKaonTrackIdx);
 
@@ -4449,8 +4437,6 @@ void MultiLepPAT::beginJob()
     X_One_Tree_->Branch("SinglePhi_prefitPt", &SinglePhi_prefitPt);
     X_One_Tree_->Branch("SinglePhi_prefitEta", &SinglePhi_prefitEta);
     X_One_Tree_->Branch("SinglePhi_prefitPhi", &SinglePhi_prefitPhi);
-    X_One_Tree_->Branch("SinglePhi_K1_nonMuonTrackIdx", &SinglePhi_K1_nonMuonTrackIdx);
-    X_One_Tree_->Branch("SinglePhi_K2_nonMuonTrackIdx", &SinglePhi_K2_nonMuonTrackIdx);
     X_One_Tree_->Branch("SinglePhi_K1_RecoKaonTrackIdx", &SinglePhi_K1_RecoKaonTrackIdx);
     X_One_Tree_->Branch("SinglePhi_K2_RecoKaonTrackIdx", &SinglePhi_K2_RecoKaonTrackIdx);
     X_One_Tree_->Branch("SinglePhi_K1_charge", &SinglePhi_K1_charge);
@@ -4492,7 +4478,6 @@ void MultiLepPAT::beginJob()
     X_One_Tree_->Branch("SinglePhi_maxAbsDxyPV", &SinglePhi_maxAbsDxyPV);
 
     X_One_Tree_->Branch("nRecoKaonTrack", &nRecoKaonTrack, "nRecoKaonTrack/I");
-    X_One_Tree_->Branch("RecoKaonTrack_nonMuonTrackIdx", &RecoKaonTrack_nonMuonTrackIdx);
     X_One_Tree_->Branch("RecoKaonTrack_pt", &RecoKaonTrack_pt);
     X_One_Tree_->Branch("RecoKaonTrack_eta", &RecoKaonTrack_eta);
     X_One_Tree_->Branch("RecoKaonTrack_phi", &RecoKaonTrack_phi);

--- a/test/ConfFile_cfg.py
+++ b/test/ConfFile_cfg.py
@@ -400,8 +400,8 @@ process.mkcands = cms.EDAnalyzer('MultiLepPAT',
         "HLT_DoubleMu4_3_LowMass_v",
     ),
     FiltersForJpsi = cms.untracked.vstring(
-        "hltVertexmumuFilterJpsiMuon3p5",
-        "hltDisplacedmumuFilterDoubleMu43LowMass",
+        "hltJpsiMuonL3Filtered3p5",
+        "hltDoubleMu43LowMassL3Filtered",
     ),
     TriggersForUpsilon = cms.untracked.vstring(
         "HLT_Trimuon5_3p5_2_Upsilon_Muon_v",

--- a/test/ConfFile_cfg_nominalLoose.py
+++ b/test/ConfFile_cfg_nominalLoose.py
@@ -309,14 +309,14 @@ process.mkcands = cms.EDAnalyzer('MultiLepPAT',
     PVMaxRho  = cms.untracked.double(2.0),
 
     # ====== Onia mass windows (GeV) ======
-    JpsiMassMin = cms.untracked.double(2.8),
-    JpsiMassMax = cms.untracked.double(3.3),
+    JpsiMassMin = cms.untracked.double(1.0),
+    JpsiMassMax = cms.untracked.double(4.0),
     UpsMassMin  = cms.untracked.double(8.0),
     UpsMassMax  = cms.untracked.double(12.0),
 
     # ====== Meson mass window (GeV) ======
-    PhiMassMin = cms.untracked.double(0.97),
-    PhiMassMax = cms.untracked.double(1.07),
+    PhiMassMin = cms.untracked.double(0.8),
+    PhiMassMax = cms.untracked.double(1.2),
 
     # ====== Track kinematics ======
     TrackPtMin = cms.untracked.double(1.0),
@@ -340,11 +340,11 @@ process.mkcands = cms.EDAnalyzer('MultiLepPAT',
     PriTrackDxyPVMax = cms.untracked.double(0.1),
 
     # ====== Per-resonance candidate pT/eta pre-cuts ======
-    JpsiCandPtMin  = cms.untracked.double(4.0),
+    JpsiCandPtMin  = cms.untracked.double(0.0),
     JpsiCandEtaMax = cms.untracked.double(999.0),
-    UpsCandPtMin   = cms.untracked.double(4.0),
+    UpsCandPtMin   = cms.untracked.double(0.0),
     UpsCandEtaMax  = cms.untracked.double(999.0),
-    PhiCandPtMin   = cms.untracked.double(2.0),
+    PhiCandPtMin   = cms.untracked.double(0.0),
     PhiCandEtaMax  = cms.untracked.double(999.0),
 
     # ====== PV selection mode ======

--- a/test/runMultiLepPAT_MCRun3_miniAOD_Run2022.py
+++ b/test/runMultiLepPAT_MCRun3_miniAOD_Run2022.py
@@ -184,7 +184,9 @@ process.mkcands = cms.EDAnalyzer('MultiLepPAT',
 
     # ====== StringCutObjectSelector-based cuts ======
     MuonSelection  = cms.untracked.string("pt > 2.5 && abs(eta) < 2.4"),
-    TrackSelection = cms.untracked.string("pt > 2.0 && abs(eta) < 2.5 && numberOfHits > 4"),
+    TrackSelection = cms.untracked.string("pt > 2.0 && abs(eta) < 2.5"),
+    TrackQuality   = cms.untracked.string("normalizedChi2 < 8 && numberOfValidHits > 4"),
+    RequireRecoKaonTrackHighPurity = cms.untracked.bool(True),
 
     # ====== Primary vertex cuts ======
     PVNdofMin = cms.untracked.int32(5),


### PR DESCRIPTION
This pull request makes significant improvements and clarifications to the documentation for the analysis framework, focusing on MC efficiency studies, configuration options, and the efficiency/acceptance scheme. The changes introduce new MC control options, expand explanations of candidate storage and branch structure, and provide a detailed description of the efficiency correction workflow.

**Key changes include:**

### MC Efficiency and Candidate Storage Documentation

- Added detailed documentation on validation testing, including how to run tests, interpret output files, and count candidates, with reference metrics for MC samples.
- Expanded instructions for running MC and single-object efficiency ntuples using `ConfFile_cfg.py`, with new options to skip composite candidate building and store all single-object candidates for efficiency studies.
- Updated the description of the core analysis flow to include new methods for storing single-object candidates and controlling candidate-building steps with CLI flags.
- Clarified and expanded the branch structure in the output TTree, including new branches for kaon daughters, single-object candidates, and the RecoKaonTrack block, as well as updated naming conventions and counter branches. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R133-R140) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L118-R163) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R96-R121)

### Configuration and Selection Cut Updates

- Updated default selection cuts for tracks and mass windows in the documentation to reflect tighter and more realistic physics selections (e.g., lower `TrackSelection` pT, narrower mass windows for J/ψ and φ). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R35)
- Added new configuration tables for candidate pT/η pre-cuts, vertex fit toggles, MC control flags, and multi-threading options, with clear descriptions and defaults.

### Efficiency and Acceptance Scheme

- Introduced a comprehensive new markdown file (`doc/Efficiency_scheme.md`) detailing the step-by-step efficiency and acceptance correction scheme, including mathematical definitions, factorization, binning strategy, and the full correction workflow.
- Provided explicit formulas for acceptance and efficiency at each stage (reconstruction, identification, candidate selection, trigger, vertexing), and explained how these are combined for the total correction factor.

These documentation updates will help users and developers understand the analysis workflow, configure MC studies, and apply efficiency corrections more effectively.